### PR TITLE
Frame size bugfix

### DIFF
--- a/xhtml2pdf/context.py
+++ b/xhtml2pdf/context.py
@@ -214,7 +214,7 @@ class pisaCSSBuilder(css.CSSBuilder):
         # box = getCoords(left, top, width, height, self.c.pageSize)
         # print "BOX", box
         # print top, left, w, h
-        return left, top, right, bottom
+        return left, top, right - left, bottom - top
 
     def _pisaAddFrame(self, name, data, first=False, border=None, size=(0,0)):
         c = self.c


### PR DESCRIPTION
Hi,

xhtml2pdf.context._pisaDimensions incorrectly returned (left, top, right, bottom), but _pisaAddFrame (the only(?) place where that method is used) expected (left, top, width, height). I've fixed it, as it caused problems with frame sizes. Would you pull my changes into your repo? holtwick says your fork is most up-to-date, that's why I'm sending the pull request to you.

Hope I've done this right... this is my first attempt at committing on github.

Cheers,

Marcus
