### PR TITLE
cached CSSCollect in xhtml2pdf/parser.py for performance improvement

### DIFF
--- a/xhtml2pdf/parser.py
+++ b/xhtml2pdf/parser.py
@@ -34,7 +34,7 @@ import types
 import xhtml2pdf.w3c.cssDOMElementInterface as cssDOMElementInterface
 import xml.dom.minidom
 
-
+CSSAttrCache={}
 
 
 log = logging.getLogger("xhtml2pdf")
@@ -220,6 +220,17 @@ def CSSCollect(node, c):
     #node.cssAttrs = {}
     #return node.cssAttrs
     if c.css:
+
+        _key = "%s_%s" % (node.parentNode, node.attributes.items())
+        try:
+            if node.parentNode.tagName.lower() != "html":
+                _key = "%s_%s" % (node.parentNode, node.attributes.items())
+                CachedCSSAttr = CSSAttrCache.get(_key, None)
+                if CachedCSSAttr is not None:
+                    return CachedCSSAttr
+        except:
+            pass
+
         node.cssElement = cssDOMElementInterface.CSSDOMElementInterface(node)
         node.cssAttrs = {}
         # node.cssElement.onCSSParserVisit(c.cssCascade.parser)
@@ -231,6 +242,9 @@ def CSSCollect(node, c):
             #    pass
             except Exception: # TODO: Kill this catch-all!
                 log.debug("CSS error '%s'", cssAttrName, exc_info=1)
+
+        CSSAttrCache[_key] = node.cssAttrs
+
     return node.cssAttrs
 
 def CSS2Frag(c, kw, isBlock):
@@ -610,6 +624,8 @@ def pisaParser(src, context, default_css="", xhtml=False, encoding=None, xml_out
     - Handle the document DOM itself and build reportlab story
     - Return Context object
     """
+
+    CSSAttrCache={}
 
     if xhtml:
         #TODO: XHTMLParser doesn't see to exist...


### PR DESCRIPTION
We do not need to call getCSSAttr if we already done it for an element with the same parent and same attributes so we can use a cache to store and reuse the result. This patch provide huge performance improvement using a cache in the CSSCollect function.
