### PR TITLE
Fix a column width related bug introduced in commit 5bc1328.

### DIFF
--- a/xhtml2pdf/xhtml2pdf_reportlab.py
+++ b/xhtml2pdf/xhtml2pdf_reportlab.py
@@ -786,7 +786,8 @@ class PmlTable(Table, PmlMaxHeightMixIn):
         if sum(newColWidths) > totalWidth:
             quotient = totalWidth / sum(newColWidths)
             # print quotient
-            newColWidths = [w * quotient for w in newColWidths]
+            for i in range(len(newColWidths)):
+                newColWidths[i] = newColWidths[i] * quotient
 
         # To avoid rounding errors adjust one col with the difference
         diff = sum(newColWidths) - totalWidth


### PR DESCRIPTION
Commit 5bc1328 introduced a bug in column width:

```
-            for i in range(len(newColWidths)):
-                newColWidths[i] = newColWidths[i] * quotient
+            newColWidths = [w * quotient for w in newColWidths]
```

While this patch may seem harmless, the result is quite shocking on table layout.

Look at this line:

```
         newColWidths = self._colWidths
```

By assigning a new list to the variable newColWidths you lose the reference with self._colWidths and it does not change...

This patch revert the offending change.
