### PR TITLE
updated httplib2 to 0.7.6, seems 0.6.0 is no longer in pypi

### DIFF
--- a/requirements.xml
+++ b/requirements.xml
@@ -1,7 +1,7 @@
 PIL==1.1.7
 coverage==3.5
 html5lib==0.90
-httplib2==0.6.0
+httplib2==0.7.6
 nose==1.0.0
 pyPdf==1.13
 reportlab==2.5


### PR DESCRIPTION
I was going through the readme trying to run the tests and pip install -r requirements.xml was failing because apparently httplib2==0.6.0 is no longer in pypi.  Updating it to 0.7.6 worked and all the tests are still passing.

Thanks!
