### PR TITLE
Don't assume filename is a string in _getFileDeprecated

### DIFF
--- a/xhtml2pdf/context.py
+++ b/xhtml2pdf/context.py
@@ -860,9 +860,9 @@ class pisaContext(object):
 
     def _getFileDeprecated(self, name, relative):
         try:
+            path = relative or self.pathDirectory
             if name.startswith("data:"):
                 return name
-            path = relative or self.pathDirectory
             if self.pathCallback is not None:
                 nv = self.pathCallback(name, relative)
             else:


### PR DESCRIPTION
With this css rule:

```
src: url('css/font/proximanova-regular.ttf') format('truetype');
```

the name passed to _getFileDeprecated would be a list:

[u'css/font/proximanova-regular.ttf', <CSS function: format(truetype)>]

Instead of the string that is expected:

if name.startswith("data:"):

So move path initialization before everything else since we reference it in the except code path.

`
Traceback (most recent call last):
  File "/venv/lib/python2.6/site-packages/django_xhtml2pdf/utils.py", line 62, in generate_pdf
    generate_pdf_template_object(tmpl, file_object, context)
  File "/venv/lib/python2.6/site-packages/django_xhtml2pdf/utils.py", line 41, in generate_pdf_template_object
    link_callback=fetch_resources)
  File "/venv/lib/python2.6/site-packages/xhtml2pdf/document.py", line 88, in pisaDocument
    encoding, context=context, xml_output=xml_output)
  File "/venv/lib/python2.6/site-packages/xhtml2pdf/document.py", line 56, in pisaStory
    pisaParser(src, context, default_css, xhtml, encoding, xml_output)
  File "/venv/lib/python2.6/site-packages/xhtml2pdf/parser.py", line 649, in pisaParser
    context.parseCSS()
  File "/venv/lib/python2.6/site-packages/xhtml2pdf/context.py", line 487, in parseCSS
    self.css = self.cssParser.parse(self.cssText)
  File "/venv/lib/python2.6/site-packages/xhtml2pdf/w3c/cssParser.py", line 358, in parse
    src, stylesheet = self._parseStylesheet(src)
  File "/venv/lib/python2.6/site-packages/xhtml2pdf/w3c/cssParser.py", line 453, in _parseStylesheet
    src, atResults = self._parseAtKeyword(src)
  File "/venv/lib/python2.6/site-packages/xhtml2pdf/w3c/cssParser.py", line 570, in _parseAtKeyword
    src, result = self._parseAtFontFace(src)
  File "/venv/lib/python2.6/site-packages/xhtml2pdf/w3c/cssParser.py", line 689, in _parseAtFontFace
    result = [self.cssBuilder.atFontFace(properties)]
  File "/venv/lib/python2.6/site-packages/xhtml2pdf/context.py", line 171, in atFontFace
    src = self.c.getFile(data["src"])
  File "/venv/lib/python2.6/site-packages/xhtml2pdf/context.py", line 886, in getFile
    return getFile(self._getFileDeprecated(name, relative))
  File "/venv/lib/python2.6/site-packages/xhtml2pdf/context.py", line 879, in _getFileDeprecated
    log.warn(self.warning("getFile %r %r %r", name, relative, path), exc_info=1)
UnboundLocalError: local variable 'path' referenced before assignment
`
