### PR TITLE
Fixed import issues `test/simple.py` and the example in `doc/usage.rst`

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -80,7 +80,7 @@ a simple "Hello World" example:
 
     def helloWorld():
       filename = __file__ + ".pdf"               (2)
-      pdf = xhtml2pdf.document.pisaDocument(     (3)
+      pdf = xhtml2pdf.pisa.CreatePDF(            (3)
         "Hello <strong>World</strong>",
         file(filename, "wb"))
       if not pdf.err:                            (4)

--- a/test/simple.py
+++ b/test/simple.py
@@ -24,7 +24,7 @@ import cgi
 import cStringIO
 import logging
 
-import ho.pisa as pisa
+import xhtml2pdf.pisa as pisa
 
 # Shortcut for dumping all logs to the screen
 pisa.showLogging()


### PR DESCRIPTION
The `CreatePDF` function is present in `xhtml2pdf.pisa`, edited both `test/simple.py` and `doc/usage.rst` to reflect that.
