### PR TITLE
Fix for a specific page size (different from standard ones)

### DIFF
--- a/xhtml2pdf/context.py
+++ b/xhtml2pdf/context.py
@@ -229,7 +229,7 @@ class pisaCSSBuilder(css.CSSBuilder):
                     log.warn(c.warning("Unknown size value for @page"))
 
             if len(sizeList) == 2:
-                c.pageSize = sizeList
+                c.pageSize = tuple(sizeList)
             if isLandscape:
                 c.pageSize = landscape(c.pageSize)
 


### PR DESCRIPTION
When using the CSS rule to set arbitrary page size (i.e. not in
xhtml2pdf.default.PML_PAGESIZES), an error is raised.
pisaCSSBuilder requires a tuple of values to set width and height of a
page in his  self.c.pageSize
