### PR TITLE
Update PIL in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     maintainer_email="tribaal@gmail.com",
     url="http://www.xhtml2pdf.com",
     keywords="PDF, HTML, XHTML, XML, CSS",
-    install_requires = ["html5lib", "pypdf", "pil", "reportlab"],
+    install_requires = ["html5lib", "pypdf", "PIL", "reportlab"],
     include_package_data = True,
     packages=find_packages(exclude=["tests", "tests.*"]),
 #    test_suite = "tests", They're not even working yet


### PR DESCRIPTION
pip has trouble installing this because it is looking for `pil` rather than `PIL`. This pull request fixes that.

Interestingly, when you use pypi's simple url (https://pypi.python.org/simple/pil/) it redirects you to PIL, and `python setup.py install` looks to that simple url.

This fixes it!
