### PR TITLE
Prevent errors when weird images are encountered

### DIFF
--- a/xhtml2pdf/xhtml2pdf_reportlab.py
+++ b/xhtml2pdf/xhtml2pdf_reportlab.py
@@ -516,9 +516,9 @@ class PmlParagraph(Paragraph, PmlMaxHeightMixIn):
         availHeight = self.getMaxHeight()
         for frag in self.frags:
             if hasattr(frag, "cbDefn") and frag.cbDefn.kind == "img":
+                img = frag.cbDefn
                 if img.width > 0 and img.height > 0:
                     self.hasImages = True
-                    img = frag.cbDefn
                     width = min(img.width, availWidth)
                     wfactor = float(width) / img.width
                     height = min(img.height, availHeight * MAX_IMAGE_RATIO)  # XXX 99% because 100% do not work...


### PR DESCRIPTION
I'm making reports with external images (so I can't anticipate whether or not the images are formatted correctly or not). But the code was previously throwing ZeroDivisionErrors and non-existent attribute errors. Instead the code should continue and render the report.
