### PR TITLE
Fix for 8-Bit PNGs

### DIFF
--- a/xhtml2pdf/xhtml2pdf_reportlab.py
+++ b/xhtml2pdf/xhtml2pdf_reportlab.py
@@ -440,7 +440,13 @@ class PmlImageReader(object):  # TODO We need a factory here, returning either a
                 palette = palette.data
             else:
                 return None
-            return map(ord, palette[transparency:transparency + 3])
+
+            # 8-bit PNGs could give an empty string as transparency value, so
+            # we have to be careful here.
+            try:
+                return map(ord, palette[transparency:transparency + 3])
+            except:
+                return None
         else:
             return None
 


### PR DESCRIPTION
The transparency variable can contain an empty string on 8-Bit PNGs, which caused an exception.
