### PR TITLE
Bugfix for images on Jython

### DIFF
--- a/xhtml2pdf/xhtml2pdf_reportlab.py
+++ b/xhtml2pdf/xhtml2pdf_reportlab.py
@@ -452,9 +452,15 @@ class PmlImageReader(object):  # TODO We need a factory here, returning either a
 
     def __str__(self):
         try:
-            return "PmlImageObject_%s" % hash(self.fileName.read())
+            fn = self.fileName.read()
+            if not fn:
+                fn = id(self)
+            return "PmlImageObject_%s" % hash(fn)
         except:
-            return self.fileName
+            fn = self.fileName
+            if not fn:
+                fn = id(self)
+            return fn
 
 
 class PmlImage(Flowable, PmlMaxHeightMixIn):


### PR DESCRIPTION
On Jython `self.fileName.read()` always returns an empty string - don't know really why, as it is working on CPython. This caused reportlab to always render the first image for all images in the PDF.
