### PR TITLE
Fix a sneaky bug in the css cache

### DIFF
--- a/xhtml2pdf/parser.py
+++ b/xhtml2pdf/parser.py
@@ -221,8 +221,7 @@ def getCSSAttrCacheKey(node):
             _id = v
         elif k == 'style':
             _st = v
-    return "%s#%s#%s#%s#%s" % (node.tagName, id(node.parentNode), _cl, _id, _st)
-
+    return "%s#%s#%s#%s#%s" % (id(node.parentNode), node.tagName.lower(), _cl, _id, _st)
 
 def CSSCollect(node, c):
     #node.cssAttrs = {}
@@ -626,6 +625,7 @@ def pisaParser(src, context, default_css="", xhtml=False, encoding=None, xml_out
     - Return Context object
     """
 
+    global CSSAttrCache
     CSSAttrCache = {}
 
     if xhtml:


### PR DESCRIPTION
When you call pisaParser the first time it's okay but on subsequent calls the pdf is pseudo-randomly corrupted.
1. We need node.tagName in getCSSAttrCacheKey.
2. CSSAttrCache in pisaParser() should be global else initialization has no effect.
