### PR TITLE
usage.rst is hard to follow for first-time users

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -403,53 +403,53 @@ that converts relative URLs to absolute system paths.
 
 ::
 
-import os
-from django.conf import settings
-from django.http import HttpResponse
-from django.template.loader import get_template
+    import os
+    from django.conf import settings
+    from django.http import HttpResponse
+    from django.template.loader import get_template
 
-# Convert HTML URIs to absolute system paths so xhtml2pdf can access those resources
-def link_callback(uri, rel):
-    # use short variable names
-    sUrl = settings.STATIC_URL      # Typically /static/
-    sRoot = settings.STATIC_ROOT    # Typically /home/userX/project_static/
-    mUrl = settings.MEDIA_URL       # Typically /static/media/
-    mRoot = settings.MEDIA_ROOT     # Typically /home/userX/project_static/media/
+    # Convert HTML URIs to absolute system paths so xhtml2pdf can access those resources
+    def link_callback(uri, rel):
+        # use short variable names
+        sUrl = settings.STATIC_URL      # Typically /static/
+        sRoot = settings.STATIC_ROOT    # Typically /home/userX/project_static/
+        mUrl = settings.MEDIA_URL       # Typically /static/media/
+        mRoot = settings.MEDIA_ROOT     # Typically /home/userX/project_static/media/
 
-    # convert URIs to absolute system paths
-    if uri.startswith(mUrl):
-        path = os.path.join(mRoot, uri.replace(mUrl, ""))
-    elif uri.startswith(sUrl):
-        path = os.path.join(sRoot, uri.replace(sUrl, ""))
+        # convert URIs to absolute system paths
+        if uri.startswith(mUrl):
+            path = os.path.join(mRoot, uri.replace(mUrl, ""))
+        elif uri.startswith(sUrl):
+            path = os.path.join(sRoot, uri.replace(sUrl, ""))
 
-    # make sure that file exists
-    if not os.path.isfile(path):
-            raise Exception(
-                    'media URI must start with %s or %s' % \
-                    (sUrl, mUrl))
-    return path
+        # make sure that file exists
+        if not os.path.isfile(path):
+                raise Exception(
+                        'media URI must start with %s or %s' % \
+                        (sUrl, mUrl))
+        return path
 
-def generate_pdf(request, type):
-    # Prepare context
-    data = {}
-    data['today'] = datetime.date.today()
-    data['farmer'] = 'Old MacDonald'
-    data['animals'] = [('Cow', 'Moo'), ('Goat', 'Baa'), ('Pig', 'Oink')]
+    def generate_pdf(request, type):
+        # Prepare context
+        data = {}
+        data['today'] = datetime.date.today()
+        data['farmer'] = 'Old MacDonald'
+        data['animals'] = [('Cow', 'Moo'), ('Goat', 'Baa'), ('Pig', 'Oink')]
     
-    # Render html content through html template with context
-    template = get_template('lyrics/oldmacdonald.html')
-    html  = template.render(Context(data))
+        # Render html content through html template with context
+        template = get_template('lyrics/oldmacdonald.html')
+        html  = template.render(Context(data))
  
-    # Write PDF to file
-    file = open(os.join(settings.MEDIA_ROOT, 'test.pdf'), "w+b")
-    pisaStatus = pisa.CreatePDF(html, dest=file,
-            link_callback = link_callback)
+        # Write PDF to file
+        file = open(os.join(settings.MEDIA_ROOT, 'test.pdf'), "w+b")
+        pisaStatus = pisa.CreatePDF(html, dest=file,
+                link_callback = link_callback)
     
-    # Return PDF document through a Django HTTP response
-    file.seek(0)
-    pdf = file.read()
-    file.close()            # Don't forget to close the file handle
-    return HttpResponse(pdf, mimetype='application/pdf')
+        # Return PDF document through a Django HTTP response
+        file.seek(0)
+        pdf = file.read()
+        file.close()            # Don't forget to close the file handle
+        return HttpResponse(pdf, mimetype='application/pdf')
 
 Reference
 ========


### PR DESCRIPTION
When I first tried to use xhtml2pdf inside a Django app, I found the usage.rst to be incomplete and thus difficult to understand. I had to visit many discussion forums and read the questions and answers before I got a better understanding of this product.

To prevent other users from having to do the same digging around, I decided to offer @chrisglass to rewrite usage.rst from from the perspective of a first-time user.

The flow will be:

*\* Intro **
Basic usage (immediately show code)
PDF vs HTML (conceptual differences)
Defining page layouts (@page, @frame, Static frames vs Content Frames)
Flowing HTML content through Content Frames

*\* Advanced concepts **
Keeping text and tables together
Named page templates
Switching between templates
Using xhtml2pdf in Django

*\* Reference **
More details

I welcome people's input.

Thanks!
@lingthio
