### PR TITLE
Multibyte improvements

### DIFF
--- a/xhtml2pdf/context.py
+++ b/xhtml2pdf/context.py
@@ -156,6 +156,9 @@ class pisaCSSBuilder(css.CSSBuilder):
         """
         result = self.ruleset([self.selector('*')], declarations)
         data = result[0].values()[0]
+        if "src" not in data:
+            # invalid - source is required, ignore this specification
+            return {}, {}
         names = data["font-family"]
 
         # Font weight
@@ -759,9 +762,13 @@ class pisaContext(object):
         """
         # print names, self.fontList
         if type(names) is not types.ListType:
-            names = str(names).strip().split(",")
+            if type(names) not in types.StringTypes:
+                names = str(names)
+            names = names.strip().split(",")
         for name in names:
-            font = self.fontList.get(str(name).strip().lower(), None)
+            if type(name) not in types.StringTypes:
+                name = str(name)
+            font = self.fontList.get(name.strip().lower(), None)
             if font is not None:
                 return font
         return self.fontList.get(default, None)
@@ -769,7 +776,9 @@ class pisaContext(object):
     def registerFont(self, fontname, alias=[]):
         self.fontList[str(fontname).lower()] = str(fontname)
         for a in alias:
-            self.fontList[str(a)] = str(fontname)
+            if type(fontname) not in types.StringTypes:
+                fontname = str(fontname)
+            self.fontList[str(a)] = fontname
 
     def loadFont(self, names, src, encoding="WinAnsiEncoding", bold=0, italic=0):
 

--- a/xhtml2pdf/parser.py
+++ b/xhtml2pdf/parser.py
@@ -636,7 +636,9 @@ def pisaParser(src, context, default_css="", xhtml=False, encoding=None, xml_out
 
     if type(src) in types.StringTypes:
         if type(src) is types.UnicodeType:
-            encoding = "utf8"
+            # If an encoding was provided, do not change it.
+            if not encoding:
+                encoding = "utf-8"
             src = src.encode(encoding)
         src = pisaTempFile(src, capacity=context.capacity)
 
@@ -656,7 +658,7 @@ def pisaParser(src, context, default_css="", xhtml=False, encoding=None, xml_out
         encoding=encoding)
 
     if xml_output:
-        xml_output.write(document.toprettyxml(encoding="utf8"))
+        xml_output.write(document.toprettyxml(encoding=encoding))
 
     if default_css:
         context.addCSS(default_css)

--- a/xhtml2pdf/reportlab_paragraph.py
+++ b/xhtml2pdf/reportlab_paragraph.py
@@ -1391,7 +1391,7 @@ class Paragraph(Flowable):
         if len(self.frags) > 1:
             autoLeading = getattr(self, 'autoLeading', getattr(style, 'autoLeading', ''))
             calcBounds = autoLeading not in ('', 'off')
-            return cjkFragSplit(self.frags, maxWidths, calcBounds)
+            return cjkFragSplit(self.frags, maxWidths, calcBounds, self.encoding)
 
         elif not len(self.frags):
             return ParaLines(kind=0, fontSize=style.fontSize, fontName=style.fontName,

--- a/xhtml2pdf/util.py
+++ b/xhtml2pdf/util.py
@@ -93,10 +93,14 @@ class memoized(object):
         # trying to memoize
         args_plus = tuple(kwargs.iteritems())
         key = (args, args_plus)
-        if key not in self.cache:
-            res = self.func(*args, **kwargs)
-            self.cache[key] = res
-        return self.cache[key]
+        try:
+            if key not in self.cache:
+                res = self.func(*args, **kwargs)
+                self.cache[key] = res
+            return self.cache[key]
+        except TypeError:
+            # happens if any of the parameters is a list
+            return self.func(*args, **kwargs)
 
 
 def ErrorMsg():

--- a/xhtml2pdf/w3c/cssParser.py
+++ b/xhtml2pdf/w3c/cssParser.py
@@ -336,6 +336,9 @@ class CSSParser(object):
         i_nmchar = _orRule('[-0-9A-Za-z_]', i_nonascii, i_escape)
         i_ident = '((?:%s)(?:%s)*)' % (i_nmstart, i_nmchar)
         re_ident = re.compile(i_ident, _reflags)
+        # Caution: treats all characters above 0x7f as legal for an identifier.
+        i_unicodeid = ur'([^\u0000-\u007f]+)'
+        re_unicodeid = re.compile(i_unicodeid, _reflags)
         i_element_name = '((?:%s)|\*)' % (i_ident[1:-1],)
         re_element_name = re.compile(i_element_name, _reflags)
         i_namespace_selector = '((?:%s)|\*|)\|(?!=)' % (i_ident[1:-1],)
@@ -1136,6 +1139,11 @@ class CSSParser(object):
         if result is not None:
             if nsPrefix is not None:
                 result = self.cssBuilder.resolveNamespacePrefix(nsPrefix, result)
+            term = self.cssBuilder.termIdent(result)
+            return src.lstrip(), term
+
+        result, src = self._getMatchResult(self.re_unicodeid, src)
+        if result is not None:
             term = self.cssBuilder.termIdent(result)
             return src.lstrip(), term
 


### PR DESCRIPTION
We have been using xhtml2pdf in our product.  It's been working well, but we have been having problems with Asian character sets.  In investigating that, I have found the these changes very useful.  Note, we have been working most with UTF-8 files, but also with GB-2312 encoding.

1) Using str() on unicode strings that contain multibyte characters
causes errors.  Test data type before using str()
2) Can't assume utf-8 encoding for input if another encoding was passed
in.  This is only a partial fix for this problem.
3) We have seen identifiers made up of multibyte characters in the CSS
input.  Add rudimentary ability to handle them.
4) In our input, about half the functions that use the memoize decorator
eventually will receive an array as a parameter.  Hardened the decorator
to handle that case.  NOTE: no tests have been run to see if I've killed
the efficiency and thus made the decorator useless.
5) The @font-face construct requires a 'src' parameter.  Later code
assumes it's there.  Ignore the instance if it doesn't exist.
