### PR TITLE
Correction to Multibyte improvements

### DIFF
--- a/xhtml2pdf/parser.py
+++ b/xhtml2pdf/parser.py
@@ -658,7 +658,11 @@ def pisaParser(src, context, default_css="", xhtml=False, encoding=None, xml_out
         encoding=encoding)
 
     if xml_output:
-        xml_output.write(document.toprettyxml(encoding=encoding))
+        if encoding:
+            xml_output.write(document.toprettyxml(encoding=encoding))
+        else:
+            xml_output.write(document.toprettyxml(encoding="utf8"))
+
 
     if default_css:
         context.addCSS(default_css)


### PR DESCRIPTION
After the last commit, I realized we could end up sending an
encoding of None to toprettyxml(), where before it was always "utf-8".
The documentation for the method does not specify how it would handle
None, so we should avoid it.
