### PR TITLE
im.tostring() -> im.tobytes() - fixed deprecation warning.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ htmlcov/
 xhtml2pdf.egg-info
 *.pdf
 tests/_trial_temp/
+.idea/*

--- a/xhtml2pdf/xhtml2pdf_reportlab.py
+++ b/xhtml2pdf/xhtml2pdf_reportlab.py
@@ -421,7 +421,7 @@ class PmlImageReader(object):  # TODO We need a factory here, returning either a
                 elif mode not in ('L', 'RGB', 'CMYK'):
                     im = im.convert('RGB')
                     self.mode = 'RGB'
-                self._data = im.tostring()
+                self._data = im.tobytes()
         return self._data
 
     def getImageData(self):


### PR DESCRIPTION
This a fix for issue #122.
