### PR TITLE
Fix CSS Issues

### DIFF
--- a/xhtml2pdf/w3c/css.py
+++ b/xhtml2pdf/w3c/css.py
@@ -672,12 +672,9 @@ class CSSRuleset(dict):
 
 
     def findCSSRuleFor(self, element, attrName):
-        try:
-            return [None for nodeFilter, declarations in self.iteritems() if
-                    (attrName in declarations) and (nodeFilter.matches(element)) and stopIter(
-                        (nodeFilter, declarations))]
-        except StopIteration:
-            return [(nodeFilter, declarations)]
+        # rule is packed in a list to differentiate from "no rule" vs "rule
+        # whose value evalutates as False"
+        return self.findCSSRulesFor(element, attrName)[-1:]
 
 
     def mergeStyles(self, styles):


### PR DESCRIPTION
I was getting incorrect CSS for my pdfs and eventually traced it back to the fact that it was not getting the correct rules for each element. It would also have different results when run multiple times. 

The change to `CSSRuleset.findCSSRuleFor` in `/w3c/css.py` in commit ce849925362c0ce9f5c1ef0a75a1095374aacf72 is what I believe caused this issue. What this change did was get the first matching CSS rule it found and return that. Since the ordering of the keys in a dict is arbitrary, the order of the CSS rules would change between runs of the program. This caused issues for me since I had the following CSS

``` css
td {font-size: 100%;}
td.hedSm {font-size: 7pt;}
```

If the `td.hedSm` nodeFilter occurred before the `td` nodeFilter in `CSSRuleset.iteritems()`, the correct CSS would be applied to my `td.hedSm`. However, sometimes they occurred in the opposite order, causing the `td.hedSm` to be ignored, and the simple `td` CSS to be applied.

Reverting this method to essentially how it worked before ce849925362c0ce9f5c1ef0a75a1095374aacf72 solved my issue since the method `CSSRuleset.findCSSRulesFor` returns a sorted list of all matching rules for an element and attrName so the desired rule is the _last_ rule from that.

This may also be a solution to issues #108, #102, and could be part of the issue in #69
