### PR TITLE
availHeight overwritten in _calcImageMaxSizes()

### DIFF
--- a/xhtml2pdf/xhtml2pdf_reportlab.py
+++ b/xhtml2pdf/xhtml2pdf_reportlab.py
@@ -527,7 +527,6 @@ class PmlParagraphAndImage(ParagraphAndImage, PmlMaxHeightMixIn):
 class PmlParagraph(Paragraph, PmlMaxHeightMixIn):
     def _calcImageMaxSizes(self, availWidth, availHeight):
         self.hasImages = False
-        availHeight = self.getMaxHeight()
         for frag in self.frags:
             if hasattr(frag, "cbDefn") and frag.cbDefn.kind == "img":
                 img = frag.cbDefn
@@ -556,7 +555,7 @@ class PmlParagraph(Paragraph, PmlMaxHeightMixIn):
         availHeight -= self.deltaHeight
 
         # Modify maxium image sizes
-        self._calcImageMaxSizes(availWidth, self.getMaxHeight() - self.deltaHeight)
+        self._calcImageMaxSizes(availWidth, availHeight)
 
         # call the base class to do wrapping and calculate the size
         Paragraph.wrap(self, availWidth, availHeight)


### PR DESCRIPTION
The deltaHeight (which accounts for the vertical padding on the image) was being ignored, resulting in some large images crashing xhtml2pdf
