### PR TITLE
Replaced pyPdf with PyPDF2.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ coverage==3.5
 html5lib==0.90
 httplib2==0.7.6
 nose==1.0.0
-pyPdf==1.13
+pyPdf2==1.19
 reportlab==2.5

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     maintainer_email="tribaal@gmail.com",
     url="http://www.xhtml2pdf.com",
     keywords="PDF, HTML, XHTML, XML, CSS",
-    install_requires = ["html5lib", "pyPdf", "Pillow", "reportlab"],
+    install_requires = ["html5lib", "PyPDF2", "Pillow", "reportlab"],
     include_package_data=True,
     packages=find_packages(exclude=["tests", "tests.*"]),
     #    test_suite = "tests", They're not even working yet


### PR DESCRIPTION
This change is necessary because there are problems with installing pyPdf from
PyPI.

When I run `pip install pypdf` using pip 1.5.dev1 bundled within virtualenv’s master branch, I get the following error:

```
  Could not find any downloads that satisfy the requirement pypdf
  Some externally hosted files were ignored (use --allow-external pypdf to allow).
Cleaning up...
```

When I run `pip install pypdf --allow-external pypdf --allow-unverified pypdf`, I get:

```
ConnectionError: HTTPConnectionPool(host='stompstompstomp.com', port=80): Max retries exceeded with url: /pyPdf/ (Caused by <class 'socket.gaierror'>: [Errno -2] Name or service not known)
```

Replacing pyPdf with PyPDF2 seems to solve the problem (i.e. the tests pass).
