### PR TITLE
Fix resource leaks by using weakrefs to avoid circular references.

### DIFF
--- a/xhtml2pdf/context.py
+++ b/xhtml2pdf/context.py
@@ -476,11 +476,22 @@ class pisaContext(object):
         self.cssDefaultText += value.strip() + "\n"
 
     def parseCSS(self):
+        # This self-reference really should be refactored. But for now
+        # we'll settle for using weak references. This avoids memory
+        # leaks because the garbage collector (at least on cPython
+        # 2.7.3) isn't aggressive enough.
+        import weakref
+
         self.cssBuilder = pisaCSSBuilder(mediumSet=["all", "print", "pdf"])
-        self.cssBuilder.c = self
+        #self.cssBuilder.c = self
+        self.cssBuilder._c = weakref.ref(self)
+        pisaCSSBuilder.c = property(lambda self: self._c())
+
         self.cssParser = pisaCSSParser(self.cssBuilder)
         self.cssParser.rootPath = self.pathDirectory
-        self.cssParser.c = self
+        #self.cssParser.c = self
+        self.cssParser._c = weakref.ref(self)
+        pisaCSSParser.c = property(lambda self: self._c())
 
         self.css = self.cssParser.parse(self.cssText)
         self.cssDefault = self.cssParser.parse(self.cssDefaultText)


### PR DESCRIPTION
Tested with pisa==3.0.33 (from PyPI) but the same circular reference
seems to exist here.

Reproducing:

Create a PDF with a (large) @page background PDF. Do this a couple of
times in a long running application and you'll see more and more file
handles reference the background-pdf. (That's just a symptom of objects
not getting garbage collected.)

After applying this fix, the file handles are released and the
excessive memory usage is gone. That leads us to believe that this
fixes the problems we were having.

In our case, when reproducing, we still had /some/ file handles open
after the fix, but an explicit call to `gc.collect()` cleared those too.
