### PR TITLE
Fix headers/footers in landscape mode.

### DIFF
--- a/xhtml2pdf/context.py
+++ b/xhtml2pdf/context.py
@@ -182,6 +182,8 @@ class pisaCSSBuilder(css.CSSBuilder):
         c = self.c
         if not name:
             name = "-pdf-frame-%d" % c.UID()
+        if data.get('is_landscape', False):
+            size = (size[1], size[0])
         x, y, w, h = getFrameDimensions(data, size[0], size[1])
         # print name, x, y, w, h
         #if not (w and h):


### PR DESCRIPTION
Now you need to set a "is_landscape:1" line in your header and footer CSS in addition
to "size:a4 landscape" in the @page frame.
