### PR TITLE
Quick fix to limit reportlab version range.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     maintainer_email="tribaal@gmail.com",
     url="http://www.xhtml2pdf.com",
     keywords="PDF, HTML, XHTML, XML, CSS",
-    install_requires = ["html5lib", "pyPdf2", "Pillow", "reportlab"],
+    install_requires = ["html5lib", "pyPdf2", "Pillow", "reportlab>=2.2,<3.0"],
     include_package_data=True,
     packages=find_packages(exclude=["tests", "tests.*"]),
     #    test_suite = "tests", They're not even working yet


### PR DESCRIPTION
Version 3.0, if installed, will not be detected by xhtml2pdf, so instead define the reportlab dependency as a range (>=2.2, <3.0).
