### PR TITLE
Fixed reportlab version check, which doesn't handle release 3.0.

### DIFF
--- a/xhtml2pdf/util.py
+++ b/xhtml2pdf/util.py
@@ -35,10 +35,11 @@ import urlparse
 
 rgb_re = re.compile("^.*?rgb[(]([0-9]+).*?([0-9]+).*?([0-9]+)[)].*?[ ]*$")
 
-if not (reportlab.Version[0] == "2" and reportlab.Version[2] >= "1"):
+_reportlab_version = tuple(map(int, reportlab.Version.split('.')))
+if _reportlab_version < (2,1):
     raise ImportError("Reportlab Version 2.1+ is needed!")
 
-REPORTLAB22 = (reportlab.Version[0] == "2" and reportlab.Version[2] >= "2")
+REPORTLAB22 = _reportlab_version >= (2, 2)
 # print "***", reportlab.Version, REPORTLAB22, reportlab.__file__
 
 log = logging.getLogger("xhtml2pdf")


### PR DESCRIPTION
Your reportlab version check relies on literal string matching to the character "2", which prevents it from working for the newly released reportlab 3.0. I changed this to compare tuples of integers, to maintain the logic while extending it to support a linear progression of version numbers.
