### PR TITLE
Ability to set offset on pagenumber

### DIFF
--- a/xhtml2pdf/default.py
+++ b/xhtml2pdf/default.py
@@ -140,6 +140,7 @@ TAGS = {
 
     "pdfpagenumber": (0, {
         "example": (STRING, "0"),
+        "offset": (INT, 0)
     }),
 
     "pdfpagecount": (0, {

--- a/xhtml2pdf/tags.py
+++ b/xhtml2pdf/tags.py
@@ -518,11 +518,12 @@ class pisaTagPDFSPACER(pisaTag):
 
 class pisaTagPDFPAGENUMBER(pisaTag):
     """
-    <pdf:pagenumber example="" />
+    <pdf:pagenumber example="" offset="" />
     """
 
     def start(self, c):
         c.frag.pageNumber = True
+        c.frag.pageOffset = self.attr.offset
         c.addFrag(self.attr.example)
         c.frag.pageNumber = False
 

--- a/xhtml2pdf/xhtml2pdf_reportlab.py
+++ b/xhtml2pdf/xhtml2pdf_reportlab.py
@@ -258,7 +258,7 @@ class PmlPageTemplate(PageTemplate):
                     if isinstance(obj, PmlParagraph):
                         for frag in obj.frags:
                             if frag.pageNumber:
-                                frag.text = str(pagenumber)
+                                frag.text = str(pagenumber + frag.pageOffset)
                             elif frag.pageCount:
                                 frag.text = str(canvas._doctemplate._page_count)
 


### PR DESCRIPTION
Hi Chris, when you've got time please take a look here.
It allows to create an offset on page numbering so that instead of your title page always being 1 you can have it as 0 with hidden number and than start displaying pagenumbers from 1 on content.

This said it only covers pdf:pagenumber and I think the same thing should be added to pdf:pagecount so you don't end up in a situation of last page being 33/34. 
