### PR TITLE
Update setup.py to allow reportlab 3.0.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     maintainer_email="tribaal@gmail.com",
     url="http://www.xhtml2pdf.com",
     keywords="PDF, HTML, XHTML, XML, CSS",
-    install_requires = ["html5lib", "pyPdf2", "Pillow", "reportlab>=2.2,<3.0"],
+    install_requires = ["html5lib", "pyPdf2", "Pillow", "reportlab>=2.2"],
     include_package_data=True,
     packages=find_packages(exclude=["tests", "tests.*"]),
     #    test_suite = "tests", They're not even working yet


### PR DESCRIPTION
This is complementary to 52d970, to allow xhtml2pdf to be used with reportlab 3.0.
