### PR TITLE
compatibility with python 3.x

### DIFF
--- a/xhtml2pdf/w3c/cssParser.py
+++ b/xhtml2pdf/w3c/cssParser.py
@@ -337,7 +337,7 @@ class CSSParser(object):
         i_ident = '((?:%s)(?:%s)*)' % (i_nmstart, i_nmchar)
         re_ident = re.compile(i_ident, _reflags)
         # Caution: treats all characters above 0x7f as legal for an identifier.
-        i_unicodeid = ur'([^\u0000-\u007f]+)'
+        i_unicodeid = r'([^\u0000-\u007f]+)'
         re_unicodeid = re.compile(i_unicodeid, _reflags)
         i_element_name = '((?:%s)|\*)' % (i_ident[1:-1],)
         re_element_name = re.compile(i_element_name, _reflags)
@@ -432,7 +432,7 @@ class CSSParser(object):
 
             try:
                 src, stylesheet = self._parseStylesheet(src)
-            except self.ParseError, err:
+            except self.ParseError as err:
                 err.setFullCSSSource(src)
                 raise
         finally:
@@ -448,7 +448,7 @@ class CSSParser(object):
         try:
             try:
                 src, properties = self._parseDeclarationGroup(src.strip(), braces=False)
-            except self.ParseError, err:
+            except self.ParseError as err:
                 err.setFullCSSSource(src, inline=True)
                 raise
 
@@ -475,7 +475,7 @@ class CSSParser(object):
                     src, property = self._parseDeclarationProperty(src.strip(), propertyName)
                     properties.append(property)
 
-            except self.ParseError, err:
+            except self.ParseError as err:
                 err.setFullCSSSource(src, inline=True)
                 raise
 


### PR DESCRIPTION
except syntax using "as" keywords instead of comma ","
