### PR TITLE
compatibility with python 3.x

### DIFF
--- a/xhtml2pdf/__init__.py
+++ b/xhtml2pdf/__init__.py
@@ -41,8 +41,8 @@ try:
     from xhtml2pdf.util import REPORTLAB22
 
     if not REPORTLAB22:
-        raise ImportError, "Reportlab Toolkit Version 2.2 or higher needed"
-except ImportError, e:
+        raise ImportError("Reportlab Toolkit Version 2.2 or higher needed")
+except ImportError as e:
     import sys
 
     sys.stderr.write(REQUIRED_INFO % e)


### PR DESCRIPTION
using "as" keyword instead of comma in except statement
