### PR TITLE
compatibility with python 3.x

### DIFF
--- a/xhtml2pdf/w3c/cssDOMElementInterface.py
+++ b/xhtml2pdf/w3c/cssDOMElementInterface.py
@@ -68,7 +68,8 @@ class CSSDOMElementInterface(css.CSSElementInterfaceAbstract):
 
     #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-    def matchesNode(self, (namespace, tagName)):
+    def matchesNode(self, namespace_tagName):
+        namespace,tagName = namespace_tagName
         if tagName not in ('*', self.domElement.tagName):
             return False
         if namespace in (None, '', '*'):


### PR DESCRIPTION
use one parameter in matchesNode function instead of tuple parameter
