### PR TITLE
Add a PIL compatibility check

### DIFF
--- a/xhtml2pdf/xhtml2pdf_reportlab.py
+++ b/xhtml2pdf/xhtml2pdf_reportlab.py
@@ -422,7 +422,11 @@ class PmlImageReader(object):  # TODO We need a factory here, returning either a
                 elif mode not in ('L', 'RGB', 'CMYK'):
                     im = im.convert('RGB')
                     self.mode = 'RGB'
-                self._data = im.tobytes()
+                if hasattr(im, 'tobytes'):
+                    self._data = im.tobytes()
+                else:
+                    # PIL compatibility
+                    self._data = im.tostring()
         return self._data
 
     def getImageData(self):


### PR DESCRIPTION
Pillow uses `tobytes` but PIL only has the `tostring` method (which throws a DeprecationWarning on Pillow). This checks and uses the appropriate method.
