### PR TITLE
Handle uri=None In pisaFileObject.__init__()

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -19,6 +19,11 @@ class TestCase(unittest.TestCase):
         r = pisaParser(_data, c)
         self.assertEqual(c, r)
 
+    def test_getFile(self):
+        c = pisaContext(".")
+        r = pisaParser(_data, c)
+        self.assertEqual(c.getFile(None), None)
+
 def buildTestSuite():
     return unittest.defaultTestLoader.loadTestsFromName(__name__)
 

--- a/xhtml2pdf/util.py
+++ b/xhtml2pdf/util.py
@@ -533,6 +533,7 @@ class pisaFileObject:
         self.uri = None
         self.local = None
         self.tmp_file = None
+        uri = uri or str()
         uri = uri.encode('utf-8')
         log.debug("FileObject %r, Basepath: %r", uri, basepath)
 


### PR DESCRIPTION
I kept getting the cryptic error message "'NoneType' object has no attribute 'encode'" while working with the django-easy-pdf package. I traced the issue back to this edge case in xhtml2pdf.
