### PR TITLE
Five changes:

### DIFF
--- a/xhtml2pdf/tables.py
+++ b/xhtml2pdf/tables.py
@@ -280,6 +280,14 @@ class pisaTagTD(pisaTag):
             # If is value, the set it in the right place in the arry
             if width is not None:
                 tdata.colw[col] = _width(width)
+            else:
+               # If there are no child nodes, nothing within the column can change the
+               # width.  Set the column width to the sum of the right and left padding
+               # rather than letting it default.
+               if len(self.node.childNodes) == 0:
+                   width = c.frag.paddingLeft + c.frag.paddingRight
+                   tdata.colw[col] = _width(width)
+
 
         # Calculate heights
         if row + 1 > len(tdata.rowh):

--- a/xhtml2pdf/tags.py
+++ b/xhtml2pdf/tags.py
@@ -337,16 +337,16 @@ class pisaTagIMG(pisaTag):
                 img.drawWidth *= dpi96
 
                 if (width is None) and (height is not None):
-                    factor = getSize(height) / img.drawHeight
+                    factor = getSize(height, default=img.drawHeight) / img.drawHeight
                     img.drawWidth *= factor
-                    img.drawHeight = getSize(height)
+                    img.drawHeight = getSize(height, default=img.drawHeight)
                 elif (height is None) and (width is not None):
-                    factor = getSize(width) / img.drawWidth
+                    factor = getSize(width, default=img.drawWidth) / img.drawWidth
                     img.drawHeight *= factor
-                    img.drawWidth = getSize(width)
+                    img.drawWidth = getSize(width, default=img.drawWidth)
                 elif (width is not None) and (height is not None):
-                    img.drawWidth = getSize(width)
-                    img.drawHeight = getSize(height)
+                    img.drawWidth = getSize(width, default=img.drawWidth)
+                    img.drawHeight = getSize(height, default=img.drawHeight)
 
                 img.drawWidth *= img.pisaZoom
                 img.drawHeight *= img.pisaZoom

--- a/xhtml2pdf/util.py
+++ b/xhtml2pdf/util.py
@@ -33,7 +33,7 @@ import urlparse
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-rgb_re = re.compile("^.*?rgb[(]([0-9]+).*?([0-9]+).*?([0-9]+)[)].*?[ ]*$")
+rgb_re = re.compile("^.*?rgb[a]?[(]([0-9]+).*?([0-9]+).*?([0-9]+)(?:.*?(?:[01]\.(?:[0-9]+)))?[)].*?[ ]*$")
 
 if not (reportlab.Version[0] == "2" and reportlab.Version[2] >= "1"):
     raise ImportError("Reportlab Version 2.1+ is needed!")
@@ -632,10 +632,13 @@ class pisaFileObject:
 
 
 def getFile(*a, **kw):
-    file = pisaFileObject(*a, **kw)
-    if file.notFound():
+    try:
+        file = pisaFileObject(*a, **kw)
+        if file.notFound():
+            return None
+        return file
+    except:
         return None
-    return file
 
 
 COLOR_BY_NAME = {

--- a/xhtml2pdf/w3c/cssParser.py
+++ b/xhtml2pdf/w3c/cssParser.py
@@ -339,6 +339,10 @@ class CSSParser(object):
         # Caution: treats all characters above 0x7f as legal for an identifier.
         i_unicodeid = ur'([^\u0000-\u007f]+)'
         re_unicodeid = re.compile(i_unicodeid, _reflags)
+        i_unicodestr1 = ur'(\'[^\u0000-\u007f]+\')'
+        i_unicodestr2 = ur'(\"[^\u0000-\u007f]+\")'
+        i_unicodestr = _orRule(i_unicodestr1, i_unicodestr2)
+        re_unicodestr = re.compile(i_unicodestr, _reflags)
         i_element_name = '((?:%s)|\*)' % (i_ident[1:-1],)
         re_element_name = re.compile(i_element_name, _reflags)
         i_namespace_selector = '((?:%s)|\*|)\|(?!=)' % (i_ident[1:-1],)
@@ -1145,6 +1149,11 @@ class CSSParser(object):
         result, src = self._getMatchResult(self.re_unicodeid, src)
         if result is not None:
             term = self.cssBuilder.termIdent(result)
+            return src.lstrip(), term
+
+        result, src = self._getMatchResult(self.re_unicodestr, src)
+        if result is not None:
+            term = self.cssBuilder.termString(result)
             return src.lstrip(), term
 
         return self.cssBuilder.termUnknown(src)


### PR DESCRIPTION
1) When sizing an image, default to the actual size, not 0.
2) Handle strings (in CSS) containing non-ASCII characters.
3) More robust handling of file not found.
4) Extent the rgb command to also hangle the rgba command.  The fourth
   parameter (transparency) is ignored.
5) In handling the TD tag, if the TD node has no children, it there is
   nothing external to the node to define the width of the column.  Set
   the width to the sum of the right and left margin.