### PR TITLE
Fixed line length > 80 lint warnings for context.py and document.py

### DIFF
--- a/xhtml2pdf/context.py
+++ b/xhtml2pdf/context.py
@@ -168,7 +168,8 @@ class pisaCSSBuilder(css.CSSBuilder):
         fweight = str(data.get("font-weight", "normal")).lower()
         bold = fweight in ("bold", "bolder", "500", "600", "700", "800", "900")
         if not bold and fweight != "normal":
-            log.warn(self.c.warning("@fontface, unknown value font-weight '%s'", fweight))
+            log.warn(self.c.warning("@fontface, unknown value font-weight '%s'",
+                                    fweight))
 
         # Font style
         italic = str(data.get("font-style", "")).lower() in ("italic", "oblique")
@@ -189,10 +190,11 @@ class pisaCSSBuilder(css.CSSBuilder):
             size = (size[1], size[0])
         x, y, w, h = getFrameDimensions(data, size[0], size[1])
         # print name, x, y, w, h
-        #if not (w and h):
+        # if not (w and h):
         #    return None
         if first:
-            return name, None, data.get("-pdf-frame-border", border), x, y, w, h, data
+            return name, None, data.get(
+                "-pdf-frame-border", border), x, y, w, h, data
 
         return (name, data.get("-pdf-frame-content", None),
                 data.get("-pdf-frame-border", border), x, y, w, h, data)
@@ -225,10 +227,12 @@ class pisaCSSBuilder(css.CSSBuilder):
                 pageBorder = data.get("-pdf-frame-border", None)
 
         if name in c.templateList:
-            log.warn(self.c.warning("template '%s' has already been defined", name))
+            log.warn(self.c.warning(
+                "template '%s' has already been defined", name))
 
         if "-pdf-page-size" in data:
-            c.pageSize = xhtml2pdf.default.PML_PAGESIZES.get(str(data["-pdf-page-size"]).lower(), c.pageSize)
+            c.pageSize = xhtml2pdf.default.PML_PAGESIZES.get(
+                str(data["-pdf-page-size"]).lower(), c.pageSize)
 
         isLandscape = False
         if "size" in data:
@@ -258,41 +262,64 @@ class pisaCSSBuilder(css.CSSBuilder):
         padding_left = self._getFromData(data, 'padding-left', 0, getSize)
         padding_right = self._getFromData(data, 'padding-right', 0, getSize)
         padding_bottom = self._getFromData(data, 'padding-bottom', 0, getSize)
-        border_color = self._getFromData(data, ('border-top-color', 'border-bottom-color',\
-                                                'border-left-color', 'border-right-color'), None, getColor)
-        border_width = self._getFromData(data, ('border-top-width', 'border-bottom-width',\
-                                                'border-left-width', 'border-right-width'), 0, getSize)
+        border_color = self._getFromData(data, ('border-top-color',
+                                                'border-bottom-color',
+                                                'border-left-color',
+                                                'border-right-color'),
+                                         None, getColor)
+        border_width = self._getFromData(data, ('border-top-width',
+                                                'border-bottom-width',
+                                                'border-left-width',
+                                                'border-right-width'),
+                                         0, getSize)
 
-        for prop in ("margin-top", "margin-left", "margin-right", "margin-bottom",
+        for prop in ("margin-top", "margin-left",
+                     "margin-right", "margin-bottom",
                      "top", "left", "right", "bottom", "width", "height"):
             if prop in data:
-                c.frameList.append(self._pisaAddFrame(name, data, first=True, border=pageBorder, size=c.pageSize))
+                c.frameList.append(self._pisaAddFrame(name, data, first=True,
+                                                      border=pageBorder,
+                                                      size=c.pageSize))
                 break
 
         # Frames have to be calculated after we know the pagesize
         frameList = []
         staticList = []
         for fname, static, border, x, y, w, h, fdata in c.frameList:
-            fpadding_top = self._getFromData(fdata, 'padding-top', padding_top, getSize)
-            fpadding_left = self._getFromData(fdata, 'padding-left', padding_left, getSize)
-            fpadding_right = self._getFromData(fdata, 'padding-right', padding_right, getSize)
-            fpadding_bottom = self._getFromData(fdata, 'padding-bottom', padding_bottom, getSize)
-            fborder_color = self._getFromData(fdata, ('border-top-color', 'border-bottom-color',\
-                                                      'border-left-color', 'border-right-color'), border_color, getColor)
-            fborder_width = self._getFromData(fdata, ('border-top-width', 'border-bottom-width',\
-                                                      'border-left-width', 'border-right-width'), border_width, getSize)
+            fpadding_top = self._getFromData(fdata, 'padding-top',
+                                             padding_top, getSize)
+            fpadding_left = self._getFromData(fdata, 'padding-left',
+                                              padding_left, getSize)
+            fpadding_right = self._getFromData(fdata, 'padding-right',
+                                               padding_right, getSize)
+            fpadding_bottom = self._getFromData(fdata, 'padding-bottom',
+                                                padding_bottom, getSize)
+            fborder_color = self._getFromData(fdata, ('border-top-color',
+                                                      'border-bottom-color',
+                                                      'border-left-color',
+                                                      'border-right-color'),
+                                              border_color, getColor)
+            fborder_width = self._getFromData(fdata, ('border-top-width',
+                                                      'border-bottom-width',
+                                                      'border-left-width',
+                                                      'border-right-width'),
+                                              border_width, getSize)
 
             if border or pageBorder:
                 frame_border = ShowBoundaryValue()
             else:
-                frame_border = ShowBoundaryValue(color=fborder_color, width=fborder_width)
+                frame_border = ShowBoundaryValue(color=fborder_color,
+                                                 width=fborder_width)
 
-            #fix frame sizing problem.
+            # fix frame sizing problem.
             if static:
-                x, y, w, h = getFrameDimensions(fdata, c.pageSize[0], c.pageSize[1])
+                x, y, w, h = getFrameDimensions(fdata,
+                                                c.pageSize[0], c.pageSize[1])
             x, y, w, h = getCoords(x, y, w, h, c.pageSize)
             if w <= 0 or h <= 0:
-                log.warn(self.c.warning("Negative width or height of frame. Check @frame definitions."))
+                log.warn(self.c.warning(
+                    "Negative width or height of frame." +
+                    " Check @frame definitions."))
 
             frame = Frame(
                 x, y, w, h,
@@ -312,21 +339,25 @@ class pisaCSSBuilder(css.CSSBuilder):
 
         background = data.get("background-image", None)
         if background:
-            #should be relative to the css file
-            background = self.c.getFile(background, relative=self.c.cssParser.rootPath)
+            # should be relative to the css file
+            background = self.c.getFile(background,
+                                        relative=self.c.cssParser.rootPath)
 
         if not frameList:
-            log.warn(c.warning("missing explicit frame definition for content or just static frames"))
+            log.warn(c.warning("missing explicit frame definition " +
+                               "for content or just static frames"))
             fname, static, border, x, y, w, h, data = self._pisaAddFrame(name, data, first=True, border=pageBorder,
                                                                          size=c.pageSize)
             x, y, w, h = getCoords(x, y, w, h, c.pageSize)
             if w <= 0 or h <= 0:
-                log.warn(c.warning("Negative width or height of frame. Check @page definitions."))
+                log.warn(c.warning("Negative width or height of frame. " +
+                                   "Check @page definitions."))
 
             if border or pageBorder:
                 frame_border = ShowBoundaryValue()
             else:
-                frame_border = ShowBoundaryValue(color=border_color, width=border_width)
+                frame_border = ShowBoundaryValue(color=border_color,
+                                                 width=border_width)
 
             frameList.append(Frame(
                 x, y, w, h,
@@ -367,7 +398,7 @@ class pisaCSSBuilder(css.CSSBuilder):
                 self.c.frameList.append(
                     self._pisaAddFrame(name, data, size=self.c.pageSize))
 
-        return {}, {} # TODO: It always returns empty dicts?
+        return {}, {}  # TODO: It always returns empty dicts?
 
 
 class pisaCSSParser(css.CSSParser):
@@ -428,7 +459,8 @@ class pisaContext(object):
 
         self.tableData = None
 
-        self.frag = self.fragBlock = getParaFrag(ParagraphStyle('default%d' % self.UID()))
+        self.frag = self.fragBlock = getParaFrag(
+            ParagraphStyle('default%d' % self.UID()))
         self.fragList = []
         self.fragAnchor = []
         self.fragStack = []
@@ -443,7 +475,7 @@ class pisaContext(object):
         self.imageData = {}
         self.force = False
 
-        self.pathCallback = None # External callback function for path calculations
+        self.pathCallback = None  # External callback function for path calculations
 
         # Store path to document
         self.pathDocument = path or "__dummy__"
@@ -502,7 +534,8 @@ class pisaContext(object):
 
         self.css = self.cssParser.parse(self.cssText)
         self.cssDefault = self.cssParser.parse(self.cssDefaultText)
-        self.cssCascade = css.CSSCascadeStrategy(userAgent=self.cssDefault, user=self.css)
+        self.cssCascade = css.CSSCascadeStrategy(userAgent=self.cssDefault,
+                                                 user=self.css)
         self.cssCascade.parser = self.cssParser
 
     # METHODS FOR STORY
@@ -514,11 +547,13 @@ class pisaContext(object):
         return story
 
     def toParagraphStyle(self, first):
-        style = ParagraphStyle('default%d' % self.UID(), keepWithNext=first.keepWithNext)
+        style = ParagraphStyle('default%d' % self.UID(),
+                               keepWithNext=first.keepWithNext)
         style.fontName = first.fontName
         style.fontSize = first.fontSize
         style.letterSpacing = first.letterSpacing
-        style.leading = max(first.leading + first.leadingSpace, first.fontSize * 1.25)
+        style.leading = max(first.leading + first.leadingSpace,
+                            first.fontSize * 1.25)
         style.backColor = first.backColor
         style.spaceBefore = first.spaceBefore
         style.spaceAfter = first.spaceAfter
@@ -611,10 +646,13 @@ class pisaContext(object):
 
         # Find maximum lead
         maxLeading = 0
-        #fontSize = 0
+        # fontSize = 0
         for frag in self.fragList:
-            leading = getSize(frag.leadingSource, frag.fontSize) + frag.leadingSpace
-            maxLeading = max(leading, frag.fontSize + frag.leadingSpace, maxLeading)
+            leading = getSize(frag.leadingSource,
+                              frag.fontSize) + frag.leadingSpace
+            maxLeading = max(leading,
+                             frag.fontSize + frag.leadingSpace,
+                             maxLeading)
             frag.leading = leading
 
         if force or (self.text.strip() and self.fragList):
@@ -626,7 +664,8 @@ class pisaContext(object):
             if first.leadingSpace:
                 style.leading = maxLeading
             else:
-                style.leading = getSize(first.leadingSource, first.fontSize) + first.leadingSpace
+                style.leading = getSize(first.leadingSource,
+                                        first.fontSize) + first.leadingSpace
 
             bulletText = copy.copy(first.bulletText)
             first.bulletText = None
@@ -711,8 +750,10 @@ class pisaContext(object):
             frag.rise = frag.fontSize * superFraction
             frag.fontSize = max(frag.fontSize - sizeDelta, 3)
 
-       # bold, italic, and underline
-        frag.fontName = frag.bulletFontName = tt2ps(frag.fontName, frag.bold, frag.italic)
+        # bold, italic, and underline
+        frag.fontName = frag.bulletFontName = tt2ps(frag.fontName,
+                                                    frag.bold,
+                                                    frag.italic)
 
         # Replace &shy; with empty and normalize NBSP
         text = (text
@@ -784,7 +825,10 @@ class pisaContext(object):
 
     def warning(self, msg, *args):
         self.warn += 1
-        self.log.append((xhtml2pdf.default.PML_WARNING, self._getLineNumber(), str(msg), self._getFragment(50)))
+        self.log.append((xhtml2pdf.default.PML_WARNING,
+                        self._getLineNumber(),
+                        str(msg),
+                        self._getFragment(50)))
         try:
             return self.context(msg % args)
         except:
@@ -792,7 +836,8 @@ class pisaContext(object):
 
     def error(self, msg, *args):
         self.err += 1
-        self.log.append((xhtml2pdf.default.PML_ERROR, self._getLineNumber(), str(msg), self._getFragment(50)))
+        self.log.append((xhtml2pdf.default.PML_ERROR, self._getLineNumber(),
+                         str(msg), self._getFragment(50)))
         try:
             return self.context(msg % args)
         except:
@@ -808,7 +853,8 @@ class pisaContext(object):
                 nv = self.pathCallback(name, relative)
             else:
                 if path is None:
-                    log.warn("Could not find main directory for getting filename. Use CWD")
+                    log.warn("Could not find main directory " +
+                             "for getting filename. Use CWD")
                     path = os.getcwd()
                 nv = os.path.normpath(os.path.join(path, name))
                 if not (nv and os.path.isfile(nv)):
@@ -817,7 +863,8 @@ class pisaContext(object):
                 log.warn(self.warning("File '%s' does not exist", name))
             return nv
         except:
-            log.warn(self.warning("getFile %r %r %r", name, relative, path), exc_info=1)
+            log.warn(self.warning("getFile %r %r %r", name, relative, path),
+                     exc_info=1)
 
     def getFile(self, name, relative=None):
         """
@@ -851,7 +898,8 @@ class pisaContext(object):
                 fontname = str(fontname)
             self.fontList[str(a)] = fontname
 
-    def loadFont(self, names, src, encoding="WinAnsiEncoding", bold=0, italic=0):
+    def loadFont(self, names, src, encoding="WinAnsiEncoding",
+                 bold=0, italic=0):
 
         # XXX Just works for local filenames!
         if names and src:
@@ -881,7 +929,9 @@ class pisaContext(object):
 
                 # check if font has already been registered
                 if fullFontName in self.fontList:
-                    log.warn(self.warning("Repeated font embed for %s, skip new embed ", fullFontName))
+                    log.warn(self.warning(
+                        "Repeated font embed for %s, skip new embed ",
+                        fullFontName))
                 else:
 
                     # Register TTF font and special name
@@ -913,7 +963,9 @@ class pisaContext(object):
 
                 # check if font has already been registered
                 if fullFontName in self.fontList:
-                    log.warn(self.warning("Repeated font embed for %s, skip new embed", fontName))
+                    log.warn(self.warning(
+                        "Repeated font embed for %s, skip new embed",
+                        fontName))
                 else:
 
                     # Include font
@@ -921,7 +973,9 @@ class pisaContext(object):
                     fontNameOriginal = face.name
                     pdfmetrics.registerTypeFace(face)
                     # print fontName, fontNameOriginal, fullFontName
-                    justFont = pdfmetrics.Font(fullFontName, fontNameOriginal, encoding)
+                    justFont = pdfmetrics.Font(fullFontName,
+                                               fontNameOriginal,
+                                               encoding)
                     pdfmetrics.registerFont(justFont)
 
                     # Add or replace missing styles
@@ -931,7 +985,7 @@ class pisaContext(object):
                                 addMapping(fontName, bold, italic, fontNameOriginal)
 
                     # Register "normal" name and the place holder for style
-                    self.registerFont(fontName, fontAlias + [fullFontName, fontNameOriginal])
+                    self.registerFont(
+                        fontName, fontAlias + [fullFontName, fontNameOriginal])
             else:
                 log.warning(self.warning("wrong attributes for <pdf:font>"))
-

--- a/xhtml2pdf/document.py
+++ b/xhtml2pdf/document.py
@@ -28,15 +28,18 @@ log = logging.getLogger("xhtml2pdf")
 
 def pisaErrorDocument(dest, c):
     out = pisaTempFile(capacity=c.capacity)
-    out.write("<p style='background-color:red;'><strong>%d error(s) occured:</strong><p>" % c.err)
+    out.write("<p style='background-color:red;'>" +
+              "<strong>%d error(s) occured:</strong><p>" % c.err)
     for mode, line, msg, _ in c.log:
         if mode == "error":
-            out.write("<pre>%s in line %d: %s</pre>" % (mode, line, cgi.escape(msg)))
+            out.write("<pre>%s in line %d: %s</pre>"
+                      % (mode, line, cgi.escape(msg)))
 
     out.write("<p><strong>%d warning(s) occured:</strong><p>" % c.warn)
     for mode, line, msg, _ in c.log:
         if mode == "warning":
-            out.write("<p>%s in line %d: %s</p>" % (mode, line, cgi.escape(msg)))
+            out.write("<p>%s in line %d: %s</p>"
+                      % (mode, line, cgi.escape(msg)))
 
     return pisaDocument(out.getvalue(), dest, raise_exception=False)
 
@@ -73,7 +76,8 @@ def pisaStory(src, path=None, link_callback=None, debug=0, default_css=None,
 def pisaDocument(src, dest=None, path=None, link_callback=None, debug=0,
                  default_css=None, xhtml=False, encoding=None, xml_output=None,
                  raise_exception=True, capacity=100 * 1024, **kw):
-    log.debug("pisaDocument options:\n  src = %r\n  dest = %r\n  path = %r\n  link_callback = %r\n  xhtml = %r",
+    log.debug("pisaDocument options:\n  src = %r\n  dest = %r\n  " +
+              "path = %r\n  link_callback = %r\n  xhtml = %r",
               src,
               dest,
               path,
@@ -142,7 +146,7 @@ def pisaDocument(src, dest=None, path=None, link_callback=None, debug=0,
                 for bg in context.pisaBackgroundList:
                     page = input1.getPage(ctr)
                     if (bg and not bg.notFound()
-                        and (bg.mimetype == "application/pdf")):
+                            and (bg.mimetype == "application/pdf")):
                         bginput = PyPDF2.PdfFileReader(bg.getFile())
                         pagebg = bginput.getPage(0)
                         pagebg.mergePage(page)


### PR DESCRIPTION
Refactored 2 files to reduce the number of lint warnings. Most of the
warnings produced was the line length > 80. Besides that, no other
changed were made.