### PR TITLE
In suggested link_callback, handle local URI and remote ones

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -422,6 +422,8 @@ that converts relative URLs to absolute system paths.
             path = os.path.join(mRoot, uri.replace(mUrl, ""))
         elif uri.startswith(sUrl):
             path = os.path.join(sRoot, uri.replace(sUrl, ""))
+        else:
+            return uri # handle absolute uri (ie: http://some.tld/foo.png)
 
         # make sure that file exists
         if not os.path.isfile(path):


### PR DESCRIPTION
Without that patch, when using absolute external url

```
  File "xhtml2pdf-master/xhtml2pdf/util.py", line 515, in __init__
    uri = uri.encode('utf-8')
AttributeError: 'NoneType' object has no attribute 'encode'
```