### PR TITLE
fix the integration tests for compares with very large differences.

### DIFF
--- a/testrender/testrender.py
+++ b/testrender/testrender.py
@@ -4,6 +4,7 @@ import os
 import shutil
 import sys
 import glob
+import decimal
 from optparse import OptionParser
 from subprocess import Popen, PIPE
 
@@ -52,7 +53,7 @@ def create_diff_image(srcfile1, srcfile2, output_dir, options):
     outname = '%s.diff%s' % os.path.splitext(srcfile1)
     outfile = os.path.join(output_dir, outname)
     _, result = exec_cmd(options, options.compare_cmd, '-metric', 'ae', srcfile1, srcfile2, '-lowlight-color', 'white', outfile)
-    diff_value = int(result.strip())
+    diff_value = int(decimal.Decimal(result.strip()))
     if diff_value > 0:
         if not options.quiet:
             print 'Image %s differs from reference, value is %i' % (srcfile1, diff_value)


### PR DESCRIPTION
the problem:
i have a very large difference set when I run the integration tests. It looks like my PNGs are being build with a transparent background while the refs have a solid white background. 

So when I ran the integration tests I got this error:

Rendering /ddi/xhtml2pdf/git/xhtml2pdf/testrender/data/source/test-list.html
Traceback (most recent call last):
  File "./testrender.py", line 269, in <module>
    main()
  File "./testrender.py", line 213, in main
    pdf, pages, diff = render_file(filename, output_dir, ref_dir, options)
  File "./testrender.py", line 101, in render_file
    output_dir, options)
  File "./testrender.py", line 56, in create_diff_image
    diff_value = int((result.strip()))
ValueError: invalid literal for int() with base 10: '2.15983e+06'

instead of this:
Rendering /ddi/xhtml2pdf/git/xhtml2pdf/testrender/data/source/test-list.html
Image /ddi/xhtml2pdf/git/xhtml2pdf/testrender/output/test-list.page0.png differs from reference, value is 2159830

the fix:
use the decimal module to handle the different count, as a very large difference count wil come back as an exponent in a string, which int can not handle