### PR TITLE
Update html5lib link version in README.rstl

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ Requirements
 ============
 
 #. `Reportlab Toolkit 2.2+ <http://www.reportlab.org/>`_
-#. `html5lib 0.11.1+ <http://code.google.com/p/html5lib/>`_
+#. `html5lib 0.90+ <https://github.com/html5lib/html5lib-python>`_
 #. `PyPDF2 1.19+ (optional) <https://pypi.python.org/pypi/PyPDF2>`_
 
    All requirements are listed in ``requirements.txt`` file.


### PR DESCRIPTION
Link to html5lib pointed to previously removed google code page. Also, version in requirements did not match the README.