### PR TITLE
FIX: keep-in-frame was being ignored except for cells

### DIFF
--- a/xhtml2pdf/parser.py
+++ b/xhtml2pdf/parser.py
@@ -569,6 +569,9 @@ def pisaLoop(node, context, path=None, **kw):
             value = str(context.cssAttr["-pdf-keep-in-frame-mode"]).strip().lower()
             if value in ("shrink", "error", "overflow", "truncate"):
                 keepInFrameMode = value
+            else:
+                keepInFrameMode = "shrink"
+            # Added because we need a default value.
         if "-pdf-keep-in-frame-max-width" in context.cssAttr:
             keepInFrameMaxWidth = getSize("".join(context.cssAttr["-pdf-keep-in-frame-max-width"]))
         if "-pdf-keep-in-frame-max-height" in context.cssAttr:
@@ -632,7 +635,9 @@ def pisaLoop(node, context, path=None, **kw):
                 KeepInFrame(
                     content=substory,
                     maxWidth=keepInFrameMaxWidth,
-                    maxHeight=keepInFrameMaxHeight))
+                    maxHeight=keepInFrameMaxHeight,
+                    mode=keepInFrameMode))
+            # mode wasn't being used; it is necessary for tables or images at end of page.
             context.keepInFrameIndex = None
 
         # Static block, END

--- a/xhtml2pdf/tables.py
+++ b/xhtml2pdf/tables.py
@@ -325,10 +325,12 @@ class pisaTagTD(pisaTag):
         # Keep in frame if needed since Reportlab does no split inside of cells
         if not c.frag.insideStaticFrame:
             # tdata.keepinframe["content"] = cell
+            mode = c.cssAttr.get("-pdf-keep-in-frame-mode", "shrink")
+            # keepInFrame mode is passed to Platypus for rendering
             cell = PmlKeepInFrame(
                 maxWidth=0,
                 maxHeight=0,
-                mode='shrink',
+                mode=mode,
                 content=cell)
 
         c.swapStory(self.story)


### PR DESCRIPTION
This code fixes it and still uses shrink as a default; this will enable
every keep-in-frame compatible element to work correctly.

Changes in tables.py are exactly the same that those on Pull Request #221. The changes made by bmihelac only solved the keep-in-frame mode for cells. This is meant to be a more complete version of his fix.