### PR TITLE
Feature/allow setting document metadata rebase

### DIFF
--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -4,6 +4,7 @@ import io
 import tempfile
 
 from nose import tools
+from unittest import skipIf as skip_if
 
 from PyPDF2 import PdfFileReader
 
@@ -33,6 +34,13 @@ METADATA = {
     "keywords": "pdf, documents",
 }
 
+try:
+    import __pypy__
+except ImportError:
+    IN_PYPY = False
+else:
+    IN_PYPY = True
+
 
 def _compare_pdf_metadata(pdf_file, assertion):
 
@@ -54,6 +62,7 @@ def _compare_pdf_metadata(pdf_file, assertion):
         assertion(actual_value, expected_value)
 
 
+@skip_if(IN_PYPY, "This doesn't work in pypy")
 def test_document_creation_without_metadata():
     with tempfile.TemporaryFile() as pdf_file:
         pisaDocument(
@@ -63,6 +72,7 @@ def test_document_creation_without_metadata():
         _compare_pdf_metadata(pdf_file, tools.assert_not_equal)
 
 
+@skip_if(IN_PYPY, "This doesn't work in pypy")
 def test_document_creation_with_metadata():
     with tempfile.TemporaryFile() as pdf_file:
         pisaDocument(

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -1,0 +1,73 @@
+from __future__ import unicode_literals
+
+import io
+import tempfile
+
+from nose import tools
+
+from PyPDF2 import PdfFileReader
+
+from xhtml2pdf.document import pisaDocument
+
+
+HTML_CONTENT = """<!DOCTYPE html>
+<html>
+<head>
+</head>
+<body>
+    <div>
+        <h1> Hello, world! </div>
+
+        <p>
+            The quick red fox jumps over the lazy brown dog.
+        </p>
+    </div>
+</body>
+</html>"""
+
+
+METADATA = {
+    "author": "MyCorp Ltd.",
+    "title": "My Document Title",
+    "subject": "My Document Subject",
+    "keywords": "pdf, documents",
+}
+
+
+def _compare_pdf_metadata(pdf_file, assertion):
+
+    # Ensure something has been written
+    tools.assert_not_equal(pdf_file.tell(), 0)
+
+    # Rewind to the start of the file to read the pdf and get the
+    # docuemnt's metadata
+    pdf_file.seek(0)
+    pdf_reader = PdfFileReader(pdf_file)
+    pdf_info = pdf_reader.documentInfo
+
+    # Check the received metadata matches the expected metadata
+    for original_key in METADATA:
+        actual_key = "/{}".format(original_key.capitalize())
+        actual_value = pdf_info[actual_key]
+        expected_value = METADATA[original_key]
+
+        assertion(actual_value, expected_value)
+
+
+def test_document_creation_without_metadata():
+    with tempfile.TemporaryFile() as pdf_file:
+        pisaDocument(
+            src=io.StringIO(HTML_CONTENT),
+            dest=pdf_file
+        )
+        _compare_pdf_metadata(pdf_file, tools.assert_not_equal)
+
+
+def test_document_creation_with_metadata():
+    with tempfile.TemporaryFile() as pdf_file:
+        pisaDocument(
+            src=io.StringIO(HTML_CONTENT),
+            dest=pdf_file,
+            context_meta=METADATA
+        )
+        _compare_pdf_metadata(pdf_file, tools.assert_equal)

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ basepython =
     py3.5: python3.5
 commands =
     {envpython} -c "from reportlab import Version; print('%s %s' % ('Reportlab Version', Version))"
-    nosetests --with-xunit --with-coverage --cover-package=xhtml2pdf
+    {envpython} -m nose.core --with-xunit --with-coverage --cover-package=xhtml2pdf
 deps =
     Pillow>=2.0
     coverage

--- a/xhtml2pdf/document.py
+++ b/xhtml2pdf/document.py
@@ -74,16 +74,22 @@ def pisaStory(src, path=None, link_callback=None, debug=0, default_css=None,
 
 def pisaDocument(src, dest=None, path=None, link_callback=None, debug=0,
                  default_css=None, xhtml=False, encoding=None, xml_output=None,
-                 raise_exception=True, capacity=100 * 1024, **kw):
-    log.debug("pisaDocument options:\n  src = %r\n  dest = %r\n  path = %r\n  link_callback = %r\n  xhtml = %r",
+                 raise_exception=True, capacity=100 * 1024, context_meta=None,
+                 **kw):
+    log.debug("pisaDocument options:\n  src = %r\n  dest = %r\n  path = %r\n  link_callback = %r\n  xhtml = %r\n  context_meta = %r",
               src,
               dest,
               path,
               link_callback,
-              xhtml)
+              xhtml,
+              context_meta)
 
     # Prepare simple context
     context = pisaContext(path, debug=debug, capacity=capacity)
+
+    if context_meta is not None:
+        context.meta.update(context_meta)
+
     context.pathCallback = link_callback
 
     # Build story

--- a/xhtml2pdf/document.py
+++ b/xhtml2pdf/document.py
@@ -97,7 +97,7 @@ def pisaDocument(src, dest=None, path=None, link_callback=None, debug=0,
                         encoding, context=context, xml_output=xml_output)
 
     # Buffer PDF into memory
-    out = pisaTempFile(capacity=context.capacity)
+    out = io.BytesIO()
 
     doc = PmlBaseDoc(
         out,
@@ -173,14 +173,14 @@ def pisaDocument(src, dest=None, path=None, link_callback=None, debug=0,
 
     if dest is None:
         # No output file was passed - Let's use a pisaTempFile
-        dest = pisaTempFile(capacity=context.capacity)
+        dest = io.BytesIO()
     context.dest = dest
 
-    data = out.getvalue()  # TODO: That load all the tempfile in RAM - Why bother with a swapping tempfile then?
+    data = out.getvalue()
+
     if isinstance(dest, io.BytesIO):
-        # external libs can use io.BytesIO as the destination, which I think should be OK
-        # TODO: I think we should be using BytesIO in pisaTempFile
         data = data.encode("utf-8")
+
     context.dest.write(data)  # TODO: context.dest is a tempfile as well...
 
     return context


### PR DESCRIPTION
Another rebase of #257, this fixes test failures by using `BytesIO` rather than `pisaTempFile` as its scratch space for `pisaDocument` processing, and the output's `dest` will now be a `BytesIO` if unspecified.

It may be better to fix `pisaTempFile`, but that has a level of complexity I'm not willing to go near without there being significantly more in the way of tests. To be honest I've spent far too long on this already in an attempt to get a solution that works against the latest release tag to be able to be merged into the master branch - if this fix isn't palatable, feel free to fix pisaTempFile and I shall re-submit #257 without my own fix, at which point these tests should pass.
