### PR TITLE
Rm python 2.6, 3.2 and 3.3 and add 3.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,27 +1,47 @@
-*.pyc
-pisa.egg-info
-.project
-.pydevproject
-.pydevproject.bak
-.settings/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Backup files
+*~
+
+# Packages
+*.egg
+*.egg-info
+dist
+build
+eggs
+parts
+bin
+var
+sdist
+develop-eggs
+.installed.cfg
+lib
+lib64
+
+# Installer logs
+pip-log.txt
+
+# Unit test / coverage reports
+.eggs/
+.coverage
 .tox
 nosetests.xml
-PIL-1.1.7-py2.7-linux-x86_64.egg/
-bin/
-html5lib-0.90-py2.7.egg/
-include/
-lib/
-man/
-pyPdf-1.13-py2.7.egg/
-reportlab-2.5-py2.7-linux-x86_64.egg/
-tests/tmp/
-build/
-dist/
-testrender/output/
-*.swp
-.coverage
-htmlcov/
-xhtml2pdf.egg-info
-*.pdf
-tests/_trial_temp/
-.idea/*
+htmlcov
+
+# Translations
+*.mo
+
+# Mr Developer
+.mr.developer.cfg
+.project
+.pydevproject
+
+# Complexity
+output/*.html
+output/*/index.html
+
+# Sphinx
+docs/_build

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ install:
 script:
     - tox
 env:
-    - TOXENV=py26
     - TOXENV=py27
     - TOXENV=py33
     - TOXENV=py34

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,4 @@ script:
 env:
     - TOXENV=py27
     - TOXENV=py34
+    - TOXENV=py35

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,4 @@ script:
     - tox
 env:
     - TOXENV=py27
-    - TOXENV=py33
     - TOXENV=py34

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,32,33,34,35}
+envlist = py{27,33,34,35}
 
 [testenv]
 commands =


### PR DESCRIPTION
Python 2.6 is removed: Because reportlab no longer supports it

Also removes Python 3.2 and 3.3 testing since:

3.2 is not supported by reportlab
3.3 is a short-lived release, major recent stable platforms like Debian Jessy and Ubuntu Trusty ship Python 3.4.