### PR TITLE
Fix static errors raised by pyflakes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ htmlcov
 .mr.developer.cfg
 .project
 .pydevproject
+.venv
 
 # Complexity
 output/*.html

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ httplib2==0.7.6
 nose==1.3.3
 pyPdf2==1.19
 reportlab>=3.0
+six

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     maintainer_email="hello+pleaseleavemealone@darylyu.com",
     url="http://www.xhtml2pdf.com",
     keywords="PDF, HTML, XHTML, XML, CSS",
-    install_requires=["html5lib", "httplib2", "pyPdf2", "Pillow", "reportlab>=3.0"],
+    install_requires=["html5lib", "httplib2", "pyPdf2", "Pillow", "reportlab>=3.0", "six"],
     include_package_data=True,
     packages=find_packages(exclude=["tests", "tests.*"]),
     #    test_suite = "tests", They're not even working yet

--- a/xhtml2pdf/context.py
+++ b/xhtml2pdf/context.py
@@ -17,13 +17,9 @@ import logging
 import os
 import re
 import reportlab
-import sys
-#support python 3
-#from types import StringTypes, TupleType, ListType
-if sys.version[0] == '2':
-    StringTypes = (str,unicode)
-else:
-    StringTypes = (str,)
+import six
+
+
 TupleType = tuple
 ListType = list
 try:
@@ -586,7 +582,7 @@ class pisaContext(object):
 
     def addTOC(self):
         styles = []
-        for i in xrange(20):
+        for i in six.range(20):
             self.node.attributes["class"] = "pdftoclevel%d" % i
             self.cssAttr = xhtml2pdf.parser.CSSCollect(self.node, self)
             xhtml2pdf.parser.CSS2Frag(self, {
@@ -847,11 +843,11 @@ class pisaContext(object):
         """
         # print names, self.fontList
         if type(names) is not ListType:
-            if type(names) not in StringTypes:
+            if type(names) not in six.string_types:
                 names = str(names)
             names = names.strip().split(",")
         for name in names:
-            if type(name) not in StringTypes:
+            if type(name) not in six.string_types:
                 name = str(name)
             font = self.fontList.get(name.strip().lower(), None)
             if font is not None:
@@ -861,7 +857,7 @@ class pisaContext(object):
     def registerFont(self, fontname, alias=[]):
         self.fontList[str(fontname).lower()] = str(fontname)
         for a in alias:
-            if type(fontname) not in StringTypes:
+            if type(fontname) not in six.string_types:
                 fontname = str(fontname)
             self.fontList[str(a)] = fontname
 

--- a/xhtml2pdf/parser.py
+++ b/xhtml2pdf/parser.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 from __future__ import print_function, unicode_literals
 from html5lib import treebuilders, inputstream
-from xhtml2pdf.default import STRING, INT, BOOL, SIZE, COLOR, FILE
+from xhtml2pdf.default import TAGS, STRING, INT, BOOL, SIZE, COLOR, FILE
 from xhtml2pdf.default import BOX, POS, MUST, FONT
 from xhtml2pdf.util import getSize, getBool, toList, getColor, getAlign
 from xhtml2pdf.util import getBox, getPos, pisaTempFile

--- a/xhtml2pdf/parser.py
+++ b/xhtml2pdf/parser.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 from __future__ import print_function, unicode_literals
 from html5lib import treebuilders, inputstream
-from xhtml2pdf.default import TAGS, STRING, INT, BOOL, SIZE, COLOR, FILE
+from xhtml2pdf.default import STRING, INT, BOOL, SIZE, COLOR, FILE
 from xhtml2pdf.default import BOX, POS, MUST, FONT
 from xhtml2pdf.util import getSize, getBool, toList, getColor, getAlign
 from xhtml2pdf.util import getBox, getPos, pisaTempFile
@@ -30,18 +30,10 @@ import copy
 import html5lib
 import logging
 import re
-
-import sys
-#support python 3
-#import types
-if sys.version[0] == '2':
-    StringTypes = (str,unicode)
-else:
-    StringTypes = (str,)
+import six
 
 import xhtml2pdf.w3c.cssDOMElementInterface as cssDOMElementInterface
 import xml.dom.minidom
-from six import text_type
 
 CSSAttrCache = {}
 
@@ -279,7 +271,7 @@ def CSSCollect(node, c):
     return node.cssAttrs
 
 def lower(sequence):
-    if type(sequence) in StringTypes:
+    if type(sequence) in six.string_types:
         return sequence.lower()
     else:
         return sequence[0].lower()
@@ -673,7 +665,7 @@ def pisaParser(src, context, default_css="", xhtml=False, encoding=None, xml_out
     else:
         parser = html5lib.HTMLParser(tree=treebuilders.getTreeBuilder("dom"))
 
-    if isinstance(src, text_type):
+    if isinstance(src, six.text_type):
         # If an encoding was provided, do not change it.
         if not encoding:
             encoding = "utf-8"

--- a/xhtml2pdf/pdf.py
+++ b/xhtml2pdf/pdf.py
@@ -14,9 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from xhtml2pdf.util import pisaTempFile, getFile, PyPDF2
-
+import six
 import logging
+
+
+from xhtml2pdf.util import pisaTempFile, getFile, PyPDF2
 
 
 log = logging.getLogger("xhtml2pdf")
@@ -50,7 +52,7 @@ class pisaPDF:
         output = PyPDF2.PdfFileWriter()
         for pdffile in self.files:
             input = PyPDF2.PdfFileReader(pdffile)
-            for pageNumber in xrange(input.getNumPages()):
+            for pageNumber in six.range(input.getNumPages()):
                 output.addPage(input.getPage(pageNumber))
 
         if file is not None:

--- a/xhtml2pdf/pisa.py
+++ b/xhtml2pdf/pisa.py
@@ -7,6 +7,7 @@ import getopt
 import glob
 import logging
 import os
+import six
 import sys
 import tempfile
 try:
@@ -122,7 +123,7 @@ class pisaLinkLoader:
                 suffix = new_suffix
         path = tempfile.mktemp(prefix="pisa-", suffix=suffix)
         ufile = urllib2.urlopen(url)
-        tfile = file(path, "wb")
+        tfile = open(path, "wb")
         while True:
             data = ufile.read(1024)
             if not data:
@@ -252,7 +253,7 @@ def execute():
 
         if o in ("-c", "--css"):
             # CSS
-            css = file(a, "r").read()
+            css = open(a, "r").read()
 
         if o in ("--css-dump",):
             # CSS dump
@@ -321,7 +322,7 @@ def execute():
             if dest_part.lower().endswith(".html") or dest_part.lower().endswith(".htm"):
                 dest_part = ".".join(src.split(".")[:-1])
             dest = dest_part + "." + format.lower()
-            for i in xrange(10):
+            for i in six.range(10):
                 try:
                     open(dest, "wb").close()
                     break
@@ -353,7 +354,7 @@ def execute():
         if not quiet:
             print ("Converting %s to %s...") % (src, dest)
 
-        pdf = pisaDocument(
+        pisaDocument(
             fsrc,
             fdest,
             debug=debug,

--- a/xhtml2pdf/reportlab_paragraph.py
+++ b/xhtml2pdf/reportlab_paragraph.py
@@ -7,6 +7,8 @@
 
 #validate version sys.version[0] == 2 -> is python 2
 #validate version sys.version[0] == 3 -> is python 3
+import re
+import six
 import sys
 
 ###############################################################
@@ -37,7 +39,6 @@ from reportlab.lib.enums import TA_LEFT, TA_RIGHT, TA_CENTER, TA_JUSTIFY
 from reportlab.lib.textsplit import ALL_CANNOT_START
 from copy import deepcopy
 from reportlab.lib.abag import ABag
-import re
 
 
 PARAGRAPH_DEBUG = False
@@ -616,12 +617,12 @@ def splitLines0(frags, widths):
     """
 
     #initialise the algorithm
-    lines = []
     lineNum = 0
     maxW = widths[lineNum]
     i = -1
     l = len(frags)
     lim = start = 0
+    text = frags[0]
     while 1:
         #find a non whitespace character
         while i < l:
@@ -1449,7 +1450,6 @@ class Paragraph(Flowable):
             #preserving splitting algorithm
             return f.clone(kind=0, lines=self.blPara.lines)
         lines = []
-        lineno = 0
 
         self.height = 0
 
@@ -1597,7 +1597,7 @@ class Paragraph(Flowable):
                     if link: _do_link_line(0, dx, ws, tx)
 
                     #now the middle of the paragraph, aligned with the left margin which is our origin.
-                    for i in xrange(1, nLines):
+                    for i in six.range(1, nLines):
                         ws = lines[i][0]
                         t_off = dpl(tx, _offsets[i], ws, lines[i][1], noJustifyLast and i == lim)
                         if dpl != _justifyDrawParaLine: ws = 0
@@ -1605,7 +1605,7 @@ class Paragraph(Flowable):
                         if strike: _do_under_line(i, t_off + leftIndent, ws, tx, lm=0.125)
                         if link: _do_link_line(i, t_off + leftIndent, ws, tx)
                 else:
-                    for i in xrange(1, nLines):
+                    for i in six.range(1, nLines):
                         dpl(tx, _offsets[i], lines[i][0], lines[i][1], noJustifyLast and i == lim)
             else:
                 f = lines[0]
@@ -1613,7 +1613,6 @@ class Paragraph(Flowable):
                 # default?
                 dpl = _leftDrawParaLineX
                 if bulletText:
-                    oo = offset
                     offset = _drawBullet(canvas, offset, cur_y, bulletText, style)
                 if alignment == TA_LEFT:
                     dpl = _leftDrawParaLineX
@@ -1662,7 +1661,7 @@ class Paragraph(Flowable):
                 _do_post_text(tx)
 
                 #now the middle of the paragraph, aligned with the left margin which is our origin.
-                for i in xrange(1, nLines):
+                for i in six.range(1, nLines):
                     f = lines[i]
                     dpl(tx, _offsets[i], f, noJustifyLast and i == lim)
                     _do_post_text(tx)
@@ -1718,7 +1717,7 @@ if __name__ == '__main__':    # NORUNTESTS
                 words = line[1]
             nwords = len(words)
             print ('line%d: %d(%s)\n  ') % (l, nwords, str(getattr(line, 'wordCount', 'Unknown'))),
-            for w in xrange(nwords):
+            for w in six.range(nwords):
                 print ("%d:'%s'") % (w, getattr(words[w], 'text', words[w])),
             print()
 
@@ -1733,7 +1732,7 @@ if __name__ == '__main__':    # NORUNTESTS
         print ('dumpParagraphFrags(<Paragraph @ %d>) minWidth() = %.2f') % (id(P), P.minWidth())
         frags = P.frags
         n = len(frags)
-        for l in xrange(n):
+        for l in six.range(n):
             print ("frag%d: '%s' %s") % (
             l, frags[l].text, ' '.join(['%s=%s' % (k, getattr(frags[l], k)) for k in frags[l].__dict__ if k != text]))
 

--- a/xhtml2pdf/tables.py
+++ b/xhtml2pdf/tables.py
@@ -5,6 +5,7 @@ from xhtml2pdf.tags import pisaTag
 from xhtml2pdf.xhtml2pdf_reportlab import PmlTable, PmlKeepInFrame
 import copy
 import logging
+import six
 
 # Copyright 2010 Dirk Holtwick, holtwick.it
 #
@@ -267,8 +268,8 @@ class pisaTagTD(pisaTag):
         if begin != end:
             #~ print begin, end
             tdata.add_style(('SPAN', begin, end))
-            for x in xrange(begin[0], end[0] + 1):
-                for y in xrange(begin[1], end[1] + 1):
+            for x in six.range(begin[0], end[0] + 1):
+                for y in six.range(begin[1], end[1] + 1):
                     if x != begin[0] or y != begin[1]:
                         tdata.add_empty(x, y)
 

--- a/xhtml2pdf/tags.py
+++ b/xhtml2pdf/tags.py
@@ -14,9 +14,8 @@ import copy
 import logging
 import re
 import warnings
+import six
 import string
-
-from six import text_type
 
 # Copyright 2010 Dirk Holtwick, holtwick.it
 #
@@ -183,7 +182,7 @@ class pisaTagH6(pisaTagP):
 
 def listDecimal(c):
     c.listCounter += 1
-    return text_type("%d." % c.listCounter)
+    return six.text_type("%d." % c.listCounter)
 
 
 roman_numeral_map = (
@@ -215,7 +214,7 @@ def int_to_roman(i):
 def listUpperRoman(c):
     c.listCounter += 1
     roman = int_to_roman(c.listCounter)
-    return unicode("%s." % roman)
+    return six.text_type("%s." % roman)
 
 
 def listLowerRoman(c):
@@ -232,7 +231,7 @@ def listUpperAlpha(c):
         # this will probably fail for anything past the 2nd time
         alpha = string.ascii_uppercase[index - 26]
         alpha *= 2
-    return unicode("%s." % alpha)
+    return six.text_type("%s." % alpha)
 
 
 def listLowerAlpha(c):

--- a/xhtml2pdf/util.py
+++ b/xhtml2pdf/util.py
@@ -13,10 +13,10 @@ import os.path
 import re
 import reportlab
 import shutil
+import six
 import string
 import sys
 import tempfile
-from six import binary_type, BytesIO
 
 import urllib
 try:
@@ -52,14 +52,6 @@ REPORTLAB22 = _reportlab_version >= (2, 2)
 # print "***", reportlab.Version, REPORTLAB22, reportlab.__file__
 
 log = logging.getLogger("xhtml2pdf")
-
-try:
-    import cStringIO as io
-except:
-    try:
-        import StringIO as io
-    except ImportError:
-        import io
 
 try:
     import PyPDF2
@@ -403,11 +395,11 @@ GAE = "google.appengine" in sys.modules
 
 if GAE:
     STRATEGIES = (
-        BytesIO,
-        BytesIO)
+        six.BytesIO,
+        six.BytesIO)
 else:
     STRATEGIES = (
-        BytesIO,
+        six.BytesIO,
         tempfile.NamedTemporaryFile)
 
 
@@ -490,7 +482,7 @@ class pisaTempFile(object):
         self._delegate.flush()
         self._delegate.seek(0)
         value = self._delegate.read()
-        if not isinstance(value, binary_type):
+        if not isinstance(value, six.binary_type):
             value = value.encode('utf-8')
         return value
 
@@ -509,7 +501,7 @@ class pisaTempFile(object):
                     (self.tell() + len_value) >= self.capacity
             if needs_new_strategy:
                 self.makeTempFile()
-        if not isinstance(value, binary_type):
+        if not isinstance(value, six.binary_type):
             value = value.encode('utf-8')
         self._delegate.write(value)
 
@@ -596,16 +588,9 @@ class pisaFileObject:
                     self.uri = uri
                     if r1.getheader("content-encoding") == "gzip":
                         import gzip
-                        try:
-                            import cStringIO as io
-                        except:
-                            try:
-                                import StringIO as io
-                            except ImportError:
-                                import io
 
                         self.file = gzip.GzipFile(
-                            mode="rb", fileobj=io.StringIO(r1.read()))
+                            mode="rb", fileobj=six.StringIO(r1.read()))
                     else:
                         self.file = r1
                 else:

--- a/xhtml2pdf/w3c/css.py
+++ b/xhtml2pdf/w3c/css.py
@@ -32,6 +32,7 @@ Dependencies:
     sets, cssParser, re (via cssParser)
 """
 
+import os
 import sys
 
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -309,15 +310,31 @@ class CSSSelectorBase(object):
     def __str__(self):
         return self.asString()
 
+    def __eq__(self, other):
+        """Python 3"""
+        return (
+            self.specificity() == other.specificity() and
+            self.fullName == other.fullName and
+            self.qualifiers == other.qualifiers
+        )
+
+    def __lt__(self, other):
+        """Python 3"""
+        return not self.__eq__(other) and (
+            self.specificity() < other.specificity() or
+            self.fullName < other.fullName or
+            self.qualifiers < other.qualifiers
+        )
 
     def __cmp__(self, other):
-        result = cmp(self.specificity(), other.specificity())
+        """Python 2"""
+        result = cmp(self.specificity(), other.specificity())  # silence pyflakes
         if result != 0:
             return result
-        result = cmp(self.fullName, other.fullName)
+        result = cmp(self.fullName, other.fullName)  # silence pyflakes
         if result != 0:
             return result
-        result = cmp(self.qualifiers, other.qualifiers)
+        result = cmp(self.qualifiers, other.qualifiers)  # silence pyflakes
         return result
 
 
@@ -1016,7 +1033,7 @@ class CSSParser(cssParser.CSSParser):
 
     def parseExternal(self, cssResourceName):
         if os.path.isfile(cssResourceName):
-            cssFile = file(cssResourceName, 'r')
+            cssFile = open(cssResourceName, 'r')
             return self.parseFile(cssFile, True)
         raise RuntimeError("Cannot resolve external CSS file: \"%s\"" % cssResourceName)
 

--- a/xhtml2pdf/w3c/css.py
+++ b/xhtml2pdf/w3c/css.py
@@ -8,6 +8,7 @@
 ##
 ##  Modified by Dirk Holtwick <holtwick@web.de>, 2007-2008
 ##~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+from __future__ import absolute_import
 
 """CSS-2.1 engine
 
@@ -34,37 +35,21 @@ Dependencies:
 
 import os
 import sys
+import copy
+import six
+
+
+from . import cssParser
+from . import cssSpecial
+
 
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #~ To replace any for with list comprehension
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-
 def stopIter(value):
     raise StopIteration(*value)
 
-
-#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-#~ Imports
-#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-import copy
-
-
-try:
-    set
-except NameError:
-    from sets import Set as set
-
-try:
-    from . import cssParser #python 3
-except Exception:
-    import cssParser #python 2
-
-try:
-    from . import cssSpecial #python 3
-except Exception:
-    import cssSpecial #python 2
 
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #~ Constants / Variables / Etc.

--- a/xhtml2pdf/w3c/cssDOMElementInterface.py
+++ b/xhtml2pdf/w3c/cssDOMElementInterface.py
@@ -8,15 +8,9 @@
 ##
 ##  Modified by Dirk Holtwick <holtwick@web.de>, 2007-2008
 ##~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+from __future__ import absolute_import
 
-#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-#~ Imports
-#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-try:
-    from . import css #python 3
-except Exception:
-    import css #python 2
+from . import css #python 3
 
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #~ Definitions

--- a/xhtml2pdf/w3c/cssParser.py
+++ b/xhtml2pdf/w3c/cssParser.py
@@ -8,6 +8,8 @@
 ##
 ##  Modified by Dirk Holtwick <holtwick@web.de>, 2007-2008
 ##~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+from __future__ import absolute_import
+
 
 """CSS-2.1 parser.
 
@@ -28,16 +30,10 @@ Dependencies:
     re
 """
 
-#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-#~ Imports
-#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
 import re
 
-try:
-    from . import cssSpecial #python 3
-except Exception:
-    import cssSpecial #python 2
+from . import cssSpecial
+
 
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #~ Definitions

--- a/xhtml2pdf/w3c/cssParser.py
+++ b/xhtml2pdf/w3c/cssParser.py
@@ -571,7 +571,7 @@ class CSSParser(object):
             charset, src = self._getString(src)
             src = src.lstrip()
             if src[:1] != ';':
-                raise self.ParseError('@charset expected a terminating \';\'', src, ctxsrc)
+                raise self.ParseError('@charset expected a terminating \';\'', src, self.ctxsrc)
             src = src[1:].lstrip()
 
             self.cssBuilder.atCharset(charset)
@@ -774,7 +774,6 @@ class CSSParser(object):
         """
         XXX Proprietary for PDF
         """
-        ctxsrc = src
         src = src[len('@frame '):].lstrip()
         box, src = self._getIdent(src)
         src, properties = self._parseDeclarationGroup(src.lstrip())
@@ -783,7 +782,6 @@ class CSSParser(object):
 
 
     def _parseAtFontFace(self, src):
-        ctxsrc = src
         src = src[len('@font-face '):].lstrip()
         src, properties = self._parseDeclarationGroup(src)
         result = [self.cssBuilder.atFontFace(properties)]

--- a/xhtml2pdf/w3c/cssSpecial.py
+++ b/xhtml2pdf/w3c/cssSpecial.py
@@ -171,8 +171,6 @@ def splitBorder(parts):
     """
 
     width = style = color = None
-    copy_parts = parts[:]
-    # part = getNextPart(parts)
 
     if len(parts) > 3:
         log.warn("To many elements for border style %r", parts)
@@ -181,12 +179,10 @@ def splitBorder(parts):
         # Width
         if isSize(part):
             width = part
-            # part = getNextPart(parts)
 
         # Style
         elif hasattr(part, 'lower') and part.lower() in _borderStyleTable:
             style = part
-            # part = getNextPart(parts)
 
         # Color
         else:
@@ -214,7 +210,6 @@ def parseSpecialRules(declarations, debug=0):
         # FONT
         if name == "font":
             # [ [ <'font-style'> || <'font-variant'> || <'font-weight'> ]? <'font-size'> [ / <'line-height'> ]? <'font-family'> ] | inherit
-            ddlen = len(dd)
             part = getNextPart(parts)
             # Style
             if part and part in _styleTable:

--- a/xhtml2pdf/xhtml2pdf_reportlab.py
+++ b/xhtml2pdf/xhtml2pdf_reportlab.py
@@ -27,11 +27,12 @@ from reportlab.platypus.tables import Table, TableStyle
 from xhtml2pdf.reportlab_paragraph import Paragraph
 from xhtml2pdf.util import getUID, getBorderStyle
 
+import six
 import sys
 
 try:
     import StringIO
-except Exception:
+except NameError:
     from io import BytesIO
     class StringIO(object):
         StringIO = BytesIO
@@ -338,7 +339,7 @@ class PmlImageReader(object):  # TODO We need a factory here, returning either a
 
                         data = self._cache.setdefault(md5(data).digest(), data)
                     self.fp = getStringIO(data)
-                elif imageReaderFlags == - 1 and isinstance(fileName, (str, unicode)):
+                elif imageReaderFlags == - 1 and isinstance(fileName, six.text_type):
                     #try Ralf Schmitt's re-opening technique of avoiding too many open files
                     self.fp.close()
                     del self.fp  # will become a property in the next statement

--- a/xhtml2pdf/xhtml2pdf_reportlab.py
+++ b/xhtml2pdf/xhtml2pdf_reportlab.py
@@ -30,13 +30,6 @@ from xhtml2pdf.util import getUID, getBorderStyle
 import six
 import sys
 
-try:
-    import StringIO
-except NameError:
-    from io import BytesIO
-    class StringIO(object):
-        StringIO = BytesIO
-
 import cgi
 import copy
 import logging
@@ -231,7 +224,7 @@ class PmlPageTemplate(PageTemplate):
                 if self.pisaBackground.mimetype.startswith("image/"):
 
                     try:
-                        img = PmlImageReader(StringIO(self.pisaBackground.getData()))
+                        img = PmlImageReader(six.StringIO(self.pisaBackground.getData()))
                         iw, ih = img.getSize()
                         pw, ph = canvas._pagesize
 
@@ -323,7 +316,7 @@ class PmlImageReader(object):  # TODO We need a factory here, returning either a
         else:
             try:
                 self.fp = open_for_read(fileName, 'b')
-                if isinstance(self.fp, StringIO().__class__):
+                if isinstance(self.fp, six.StringIO().__class__):
                     imageReaderFlags = 0  # avoid messing with already internal files
                 if imageReaderFlags > 0:  # interning
                     data = self.fp.read()
@@ -505,7 +498,7 @@ class PmlImage(Flowable, PmlMaxHeightMixIn):
         return self.dWidth, self.dHeight
 
     def getImage(self):
-        img = PmlImageReader(StringIO(self._imgdata))
+        img = PmlImageReader(six.StringIO(self._imgdata))
         return img
 
     def draw(self):


### PR DESCRIPTION
```
xhtml2pdf/parser.py:18: 'TAGS' imported but unused
xhtml2pdf/parser.py:25: 'from xhtml2pdf.tags import *' used; unable to detect undefined names
xhtml2pdf/parser.py:26: 'from xhtml2pdf.tables import *' used; unable to detect undefined names
xhtml2pdf/parser.py:27: 'from xhtml2pdf.util import *' used; unable to detect undefined names
xhtml2pdf/tables.py:270: undefined name 'xrange'
xhtml2pdf/tables.py:271: undefined name 'xrange'
xhtml2pdf/xhtml2pdf_reportlab.py:341: undefined name 'unicode'
xhtml2pdf/context.py:24: undefined name 'unicode'
xhtml2pdf/context.py:589: undefined name 'xrange'
xhtml2pdf/util.py:62: 'io' imported but unused
xhtml2pdf/util.py:600: redefinition of unused 'io' from line 62
xhtml2pdf/paragraph2.py:680: 'from reportlab.lib.styles import *' used; unable to detect undefined names
xhtml2pdf/paragraph2.py:681: 'from reportlab.rl_config import *' used; unable to detect undefined names
xhtml2pdf/paragraph2.py:682: 'from reportlab.lib.units import *' used; unable to detect undefined names
xhtml2pdf/reportlab_paragraph.py:619: local variable 'lines' is assigned to but never used
xhtml2pdf/reportlab_paragraph.py:628: local variable 'text' (defined in enclosing scope on line 1876) referenced before assignment
xhtml2pdf/reportlab_paragraph.py:1452: local variable 'lineno' is assigned to but never used
xhtml2pdf/reportlab_paragraph.py:1600: undefined name 'xrange'
xhtml2pdf/reportlab_paragraph.py:1608: undefined name 'xrange'
xhtml2pdf/reportlab_paragraph.py:1616: local variable 'oo' is assigned to but never used
xhtml2pdf/reportlab_paragraph.py:1665: undefined name 'xrange'
xhtml2pdf/reportlab_paragraph.py:1721: undefined name 'xrange'
xhtml2pdf/reportlab_paragraph.py:1736: undefined name 'xrange'
xhtml2pdf/pisa.py:125: undefined name 'file'
xhtml2pdf/pisa.py:255: undefined name 'file'
xhtml2pdf/pisa.py:324: undefined name 'xrange'
xhtml2pdf/pisa.py:356: local variable 'pdf' is assigned to but never used
xhtml2pdf/tags.py:218: undefined name 'unicode'
xhtml2pdf/tags.py:235: undefined name 'unicode'
xhtml2pdf/pdf.py:53: undefined name 'xrange'
xhtml2pdf/paragraph.py:582: 'from reportlab.lib.styles import *' used; unable to detect undefined names
xhtml2pdf/paragraph.py:583: 'from reportlab.rl_config import *' used; unable to detect undefined names
xhtml2pdf/paragraph.py:584: 'from reportlab.lib.units import *' used; unable to detect undefined names
xhtml2pdf/w3c/css.py:314: undefined name 'cmp'
xhtml2pdf/w3c/css.py:317: undefined name 'cmp'
xhtml2pdf/w3c/css.py:320: undefined name 'cmp'
xhtml2pdf/w3c/css.py:1018: undefined name 'os'
xhtml2pdf/w3c/css.py:1019: undefined name 'file'
xhtml2pdf/w3c/cssParser.py:574: undefined name 'ctxsrc'
xhtml2pdf/w3c/cssParser.py:777: local variable 'ctxsrc' is assigned to but never used
xhtml2pdf/w3c/cssParser.py:786: local variable 'ctxsrc' is assigned to but never used
xhtml2pdf/w3c/cssSpecial.py:174: local variable 'copy_parts' is assigned to but never used
xhtml2pdf/w3c/cssSpecial.py:217: local variable 'ddlen' is assigned to but never used
```

Fixes lots of Python 3 errors and in addition has hunted down a number of errors with comparison in `CSSSelectorBase`, which might fix odd issues showing up in Python3.