### PR TITLE
Update html5 version in setup.py also

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     maintainer_email="use-github@doit.com",
     url="http://github.com/xhtml2pdf/xhtml2pdf",
     keywords="PDF, HTML, XHTML, XML, CSS",
-    install_requires=["html5lib", "httplib2", "pyPdf2", "Pillow", "reportlab>=3.0", "six"],
+    install_requires=["html5lib==1.0b8", "httplib2", "pyPdf2", "Pillow", "reportlab>=3.0", "six"],
     setup_requires=["nose>=1.0"],
     include_package_data=True,
     packages=find_packages(exclude=["tests", "tests.*"]),


### PR DESCRIPTION
Reflects requirements.txt change in 8eaf2f2b009c62258dea30aae37bd5966be6dba1

Ref #321 Fix #318

I'd suggest releasing a 0.1b3 right after merging, because current install of xhtml2pdf via setup.py is currently broken.