### PR TITLE
`mimetypes` may be unable to detect file type

### DIFF
--- a/xhtml2pdf/util.py
+++ b/xhtml2pdf/util.py
@@ -618,7 +618,7 @@ class pisaFileObject:
                     self.local = uri
                 
                     self.setMimeTypeByName(uri)
-                    if self.mimetype.startswith('text'):
+                    if self.mimetype and self.mimetype.startswith('text'):
                         self.file = open(uri, "r") #removed bytes... lets hope it goes ok :/
                     else:
                         self.file = open(uri, "rb") #removed bytes... lets hope it goes ok :/


### PR DESCRIPTION
`self.mimetype` will be `None` in that case