### PR TITLE
Cleanup logging

### DIFF
--- a/xhtml2pdf/parser.py
+++ b/xhtml2pdf/parser.py
@@ -73,7 +73,7 @@ def pisaGetAttributes(c, tag, attributes):
             if type(v) == tuple:
                 if v[1] == MUST:
                     if k not in attrs:
-                        log.warn(c.warning("Attribute '%s' must be set!", k))
+                        log.warning(c.warning("Attribute '%s' must be set!", k))
                         nattrs[k] = None
                         continue
                 nv = attrs.get(k, v[1])
@@ -88,7 +88,7 @@ def pisaGetAttributes(c, tag, attributes):
                     nv = nv.strip().lower()
                     if nv not in v:
                         #~ raise PML_EXCEPTION, "attribute '%s' of wrong value, allowed is one of: %s" % (k, repr(v))
-                        log.warn(c.warning("Attribute '%s' of wrong value, allowed is one of: %s", k, repr(v)))
+                        log.warning(c.warning("Attribute '%s' of wrong value, allowed is one of: %s", k, repr(v)))
                         nv = dfl
 
                 elif v == BOOL:
@@ -99,7 +99,7 @@ def pisaGetAttributes(c, tag, attributes):
                     try:
                         nv = getSize(nv)
                     except:
-                        log.warn(c.warning("Attribute '%s' expects a size value", k))
+                        log.warning(c.warning("Attribute '%s' expects a size value", k))
 
                 elif v == BOX:
                     nv = getBox(nv, c.pageSize)

--- a/xhtml2pdf/pisa.py
+++ b/xhtml2pdf/pisa.py
@@ -135,7 +135,7 @@ class pisaLinkLoader:
         self.tfileList.append(path)
 
         if not self.quiet:
-            print ("  Loading", url, "to", path)
+            print ("  Loading %s to %s" % (url, path))
 
         return path
 
@@ -237,12 +237,12 @@ def execute():
             print ()
             print ("SYSTEM INFORMATIONS")
             print ("--------------------------------------------")
-            print ("OS:                ", sys.platform)
-            print ("Python:            ", sys.version)
-            print ("html5lib:          ", "?")
+            print ("OS:                %s" % sys.platform)
+            print ("Python:            %s" % sys.version)
+            print ("html5lib:          ?")
             import reportlab
 
-            print ("Reportlab:         ", reportlab.Version)
+            print ("Reportlab:         %s" % reportlab.Version)
             sys.exit(0)
 
         if o in ("-t", "--format"):
@@ -351,7 +351,7 @@ def execute():
             try:
                 open(dest, "wb").close()
             except:
-                print ("File '%s' seems to be in use of another application.") % dest
+                print ("File '%s' seems to be in use of another application." % dest)
                 sys.exit(2)
             fdest = open(dest, "wb")
             fdestclose = 1
@@ -382,7 +382,7 @@ def execute():
 
         if (not errors) and startviewer:
             if not quiet:
-                print ("Open viewer for file %s") % dest
+                print ("Open viewer for file %s" % dest)
             startViewer(dest)
 
 


### PR DESCRIPTION
- Replace some debug `print` statement by logger.debug
- `Logger.warn` [is deprecated](https://docs.python.org/3/library/logging.html#logging.Logger.warning), replace it by `Logger.warning`
- Replace a few `print` statement by the `print` function in Pisa command parser. Should probably be migrated to to [argparse](https://docs.python.org/2.7/library/argparse.html) at some point?