### PR TITLE
self.mimetype may be None

### DIFF
--- a/xhtml2pdf/util.py
+++ b/xhtml2pdf/util.py
@@ -616,9 +616,9 @@ class pisaFileObject:
                 if os.path.isfile(uri):
                     self.uri = uri
                     self.local = uri
-                
+
                     self.setMimeTypeByName(uri)
-                    if self.mimetype.startswith('text'):
+                    if self.mimetype and self.mimetype.startswith('text'):
                         self.file = open(uri, "r") #removed bytes... lets hope it goes ok :/
                     else:
                         self.file = open(uri, "rb") #removed bytes... lets hope it goes ok :/
@@ -651,7 +651,7 @@ class pisaFileObject:
             try:
                 self.data = self.file.read()
             except:
-                if self.mimetype.startswith('text'):
+                if self.mimetype and self.mimetype.startswith('text'):
                     self.file = open(self.file.name, "rb") #removed bytes... lets hope it goes ok :/
                     self.data = self.file.read().decode('utf-8')
                 else:


### PR DESCRIPTION
In some environments, `mimetypes.gusss_type` can't guess the type of the file, it will return `(None, None)`. xhtml2pdf will raise `AttributeError: 'NoneType' object has no attribute 'startswith'`