### PR TITLE
Fixed a TypeError using python3

### DIFF
--- a/xhtml2pdf/reportlab_paragraph.py
+++ b/xhtml2pdf/reportlab_paragraph.py
@@ -22,7 +22,7 @@ if sys.version[0] != '2':
         def __init__(self,stream):
             super().__init__(stream,'utf-8')
     basestring = byte
-    unicode = byte #python 3
+    unicode = str #python 3
     str = byte
 
 ###############################################################

--- a/xhtml2pdf/w3c/cssParser.py
+++ b/xhtml2pdf/w3c/cssParser.py
@@ -15,6 +15,11 @@ from __future__ import absolute_import
 # Added by benjaoming to fix python3 tests
 from __future__ import unicode_literals
 
+try:
+    from future_builtins import filter
+except ImportError:
+    pass
+
 """CSS-2.1 parser.
 
 The CSS 2.1 Specification this parser was derived from can be found at http://www.w3.org/TR/CSS21/
@@ -1181,7 +1186,7 @@ class CSSParser(object):
             rexpression = self.re_string
         result = rexpression.match(src)
         if result:
-            strres = filter(None, result.groups())
+            strres = tuple(filter(None, result.groups()))
             if strres:
                 try:
                     strres = strres[0]


### PR DESCRIPTION
I fixed a TypeError using python3.

The following error occurred:

```
File "/xhtml2pdf/context.py", line
184, in atFontFace
for part in uri:
TypeError: 'NotImplementedType' object is not iterable
```

The cause is as follows:

### xhtml2pdf/w3c/cssParser.py, line 1184
```
strres = filter(None, result.groups())
```

Filter() returns an iterator in python3, not list.
So I wrapped a call to filter() with a call to tuple().
But the result becomes a two-dimensional array in python2, so I used filter() of future_builtins.

And currently code assigns a byte to unicode. Due to it, error occurred file "reportlab_paragraph.py, line 813 class cjkU(unicode). So I fixed it.

