### PR TITLE
Workaround for python 3 in css parser. It returned error in some cases.

### DIFF
--- a/xhtml2pdf/w3c/cssParser.py
+++ b/xhtml2pdf/w3c/cssParser.py
@@ -1186,7 +1186,10 @@ class CSSParser(object):
                 try:
                     strres = strres[0]
                 except Exception:
-                    strres = result.groups()[0]
+                    try:
+                        strres = list(strres)[0] # python 3, as filter returns object
+                    except Exception:
+                        strres = result.groups()[0]
             else:
                 strres = ''
             return strres, src[result.end():]


### PR DESCRIPTION
See end of https://github.com/nigma/django-easy-pdf/issues/12 (depends on xhtml2pdf)
The problem is that in python 3 filter returns a filter object, not a list. So strres[0] will return error. In that case we try to get a list from sttres (list(strres)[0]) and only then falling to the original exception handling.