### PR TITLE
Update PDF producer field

### DIFF
--- a/xhtml2pdf/xhtml2pdf_reportlab.py
+++ b/xhtml2pdf/xhtml2pdf_reportlab.py
@@ -95,7 +95,7 @@ class PmlBaseDoc(BaseDocTemplate):
     def beforePage(self):
 
         # Tricky way to set producer, because of not real privateness in Python
-        info = "pisa HTML to PDF <http://www.htmltopdf.org>"
+        info = "xhtml2pdf <https://github.com/xhtml2pdf/xhtml2pdf/>"
         self.canv._doc.info.producer = info
 
         '''


### PR DESCRIPTION
In addition to being a simple update, some SPAM filters are known to blacklist `htmltopdf.org`, making it hard to send the generated PDFs by email.