### PR TITLE
repair --nofail flag

### DIFF
--- a/testrender/testrender.py
+++ b/testrender/testrender.py
@@ -123,7 +123,8 @@ def exec_cmd(options, *args):
         print(result[0], result[1])
     if proc.returncode:
         print('exec error (%i): %s' % (proc.returncode, result[1]))
-        sys.exit(1)
+        if not options.nofail:
+            sys.exit(1)
     return result[0], result[1]
 
 


### PR DESCRIPTION
This PR repair the flag --nofail, but not repair the problem presented in travis.
--nofail ignore if some test fail,  but there is 7 testrenders failed.

There is a problem with diff an compare with image magic, I think new version of image magic breaks the testrender.   I hope to have time to check what is happen with convert and compare commands.

Now, test in travis is passing.