### PR TITLE
Fixing  TypeError with six types

### DIFF
--- a/xhtml2pdf/reportlab_paragraph.py
+++ b/xhtml2pdf/reportlab_paragraph.py
@@ -15,15 +15,10 @@ import sys
 ###############################################################
 ###############################################################
 #if not python 2, the internal behavior of strings is changed
-is_python2 = True
-if sys.version[0] != '2':
-    is_python2 = False
-    class byte(bytes):
-        def __init__(self,stream):
-            super().__init__(stream,'utf-8')
-    basestring = byte
-    unicode = str #python 3
-    str = byte
+
+basestring = six.binary_type
+unicode = six.text_type
+str = six.binary_type
 
 ###############################################################
 ###############################################################
@@ -674,8 +669,10 @@ _scheme_re = re.compile('^[a-zA-Z][-+a-zA-Z0-9]+$')
 
 
 def _doLink(tx, link, rect):
-    if isinstance(link, unicode) and is_python2:
+    try:
         link = link.encode('utf8')
+    except:
+        pass
     parts = link.split(':', 1)
     scheme = len(parts) == 2 and parts[0].lower() or ''
     if _scheme_re.match(scheme) and scheme != 'document':

--- a/xhtml2pdf/reportlab_paragraph.py
+++ b/xhtml2pdf/reportlab_paragraph.py
@@ -22,7 +22,7 @@ if sys.version[0] != '2':
         def __init__(self,stream):
             super().__init__(stream,'utf-8')
     basestring = byte
-    unicode = byte #python 3
+    unicode = str #python 3
     str = byte
 
 ###############################################################

--- a/xhtml2pdf/reportlab_paragraph.py
+++ b/xhtml2pdf/reportlab_paragraph.py
@@ -4,25 +4,15 @@
 # history http://www.reportlab.co.uk/cgi-bin/viewcvs.cgi/public/reportlab/trunk/reportlab/platypus/paragraph.py
 # Modifications by Dirk Holtwick, 2008
 
-
+from __future__ import unicode_literals
 import re
 import six
 import sys
 
-###############################################################
-###############################################################
-###############################################################
-#if not python 2, the internal behavior of strings is changed
 
-is_python2 = True
-if sys.version[0] != '2':
-    is_python2 = False
-    class byte(bytes):
-        def __init__(self,stream):
-            super().__init__(stream,'utf-8')
-    basestring = byte
-    unicode = str #python 3
-str = byte
+basestring = six.text_type
+unicode = six.text_type #python 3
+str = six.text_type
 ###############################################################
 ###############################################################
 ###############################################################
@@ -672,8 +662,8 @@ _scheme_re = re.compile('^[a-zA-Z][-+a-zA-Z0-9]+$')
 
 
 def _doLink(tx, link, rect):
-    if isinstance(link, unicode) and is_python2:
-        link = link.encode('utf8')
+    if six.PY2:
+        link = six.text_type(link, 'utf8') 
     parts = link.split(':', 1)
     scheme = len(parts) == 2 and parts[0].lower() or ''
     if _scheme_re.match(scheme) and scheme != 'document':
@@ -1280,7 +1270,11 @@ class Paragraph(Flowable):
                 endLine = (newWidth > maxWidth and n > 0) or lineBreak
                 if not endLine:
                     if lineBreak: continue      #throw it away
-                    nText = w[1][1]
+                    if type(w[1][1]) != six.text_type:
+                        nText = six.text_type(w[1][1], 'utf-8')
+                    else:
+                        nText = w[1][1]
+                        
                     if nText: n += 1
                     fontSize = f.fontSize
                     if calcBounds:

--- a/xhtml2pdf/reportlab_paragraph.py
+++ b/xhtml2pdf/reportlab_paragraph.py
@@ -5,8 +5,6 @@
 # Modifications by Dirk Holtwick, 2008
 
 
-#validate version sys.version[0] == 2 -> is python 2
-#validate version sys.version[0] == 3 -> is python 3
 import re
 import six
 import sys
@@ -16,10 +14,15 @@ import sys
 ###############################################################
 #if not python 2, the internal behavior of strings is changed
 
-basestring = six.binary_type
-unicode = six.text_type
-str = six.binary_type
-
+is_python2 = True
+if sys.version[0] != '2':
+    is_python2 = False
+    class byte(bytes):
+        def __init__(self,stream):
+            super().__init__(stream,'utf-8')
+    basestring = byte
+    unicode = str #python 3
+str = byte
 ###############################################################
 ###############################################################
 ###############################################################
@@ -669,10 +672,8 @@ _scheme_re = re.compile('^[a-zA-Z][-+a-zA-Z0-9]+$')
 
 
 def _doLink(tx, link, rect):
-    try:
+    if isinstance(link, unicode) and is_python2:
         link = link.encode('utf8')
-    except:
-        pass
     parts = link.split(':', 1)
     scheme = len(parts) == 2 and parts[0].lower() or ''
     if _scheme_re.match(scheme) and scheme != 'document':

--- a/xhtml2pdf/w3c/cssParser.py
+++ b/xhtml2pdf/w3c/cssParser.py
@@ -15,6 +15,11 @@ from __future__ import absolute_import
 # Added by benjaoming to fix python3 tests
 from __future__ import unicode_literals
 
+try:
+    from future_builtins import filter
+except ImportError:
+    pass
+
 """CSS-2.1 parser.
 
 The CSS 2.1 Specification this parser was derived from can be found at http://www.w3.org/TR/CSS21/
@@ -1181,7 +1186,7 @@ class CSSParser(object):
             rexpression = self.re_string
         result = rexpression.match(src)
         if result:
-            strres = filter(None, result.groups())
+            strres = tuple(filter(None, result.groups()))
             if strres:
                 try:
                     strres = strres[0]


### PR DESCRIPTION
This PR incorporate the PRs
*  Fixed a TypeError using python3 #361
* Workaround for python 3 in css parser. It returned error in some cases. #362

And change how str/unicode is managed, removing the class class byte(bytes) and using the six types.

