### PR TITLE
Make 'producer' field a module constant

### DIFF
--- a/xhtml2pdf/xhtml2pdf_reportlab.py
+++ b/xhtml2pdf/xhtml2pdf_reportlab.py
@@ -46,6 +46,7 @@ except:
 log = logging.getLogger("xhtml2pdf")
 
 MAX_IMAGE_RATIO = 0.95
+PRODUCER = "xhtml2pdf <https://github.com/xhtml2pdf/xhtml2pdf/>"
 
 
 class PTCycle(list):
@@ -93,10 +94,7 @@ class PmlBaseDoc(BaseDocTemplate):
     """
 
     def beforePage(self):
-
-        # Tricky way to set producer, because of not real privateness in Python
-        info = "xhtml2pdf <https://github.com/xhtml2pdf/xhtml2pdf/>"
-        self.canv._doc.info.producer = info
+        self.canv._doc.info.producer = PRODUCER
 
         '''
         # Convert to ASCII because there is a Bug in Reportlab not


### PR DESCRIPTION
Spam filters blacklist the previous version of the producer field (see #366). It is only a matter of time before spammers update to a newer version of this library, with the new value of the 'producer' field. This commit makes that field a module variable, which is much cleaner to patch at runtime when needed (it was already possible before anyway, just less elegant). Moving this constant to the top of the file also enhances readability.