### PR TITLE
fix(pisa): fix random TypeError in pisa.pisaDocument

### DIFF
--- a/xhtml2pdf/reportlab_paragraph.py
+++ b/xhtml2pdf/reportlab_paragraph.py
@@ -137,7 +137,7 @@ def _leftDrawParaLine(tx, offset, extraspace, words, last=0):
 def _centerDrawParaLine(tx, offset, extraspace, words, last=0):
     m = offset + 0.5 * extraspace
     setXPos(tx, m)
-    tx._textOut(" ".join(words), 1)
+    tx._textOut(b" ".join(words), 1)
     setXPos(tx, -m)
     return m
 


### PR DESCRIPTION
This is the error

```bash
Traceback (most recent call last):
  ...
  File "/lib/python3.6/site-packages/xhtml2pdf/document.py", line 136, in pisaDocument
    doc.build(context.story)
  File "/lib/python3.6/site-packages/reportlab/platypus/doctemplate.py", line 969, in build
    self.handle_flowable(flowables)
  File "/lib/python3.6/site-packages/reportlab/platypus/doctemplate.py", line 834, in handle_flowable
    if frame.add(f, canv, trySplit=self.allowSplitting):
  File "/lib/python3.6/site-packages/reportlab/platypus/frames.py", line 196, in _add
    flowable.drawOn(canv, self._x + self._leftExtraIndent, y, _sW=aW-w)
  File "/lib/python3.6/site-packages/reportlab/platypus/flowables.py", line 111, in drawOn
    self._drawOn(canvas)
  File "/lib/python3.6/site-packages/reportlab/platypus/flowables.py", line 92, in _drawOn
    self.draw()#this is the bit you overload
  File "/lib/python3.6/site-packages/xhtml2pdf/xhtml2pdf_reportlab.py", line 659, in draw
    Paragraph.draw(self)
  File "/lib/python3.6/site-packages/xhtml2pdf/reportlab_paragraph.py", line 1160, in draw
    self.drawPara(self.debug)
  File "/lib/python3.6/site-packages/xhtml2pdf/reportlab_paragraph.py", line 1560, in drawPara
    t_off = dpl(tx, offset, ws, lines[0][1], noJustifyLast and nLines == 1)
  File "/lib/python3.6/site-packages/xhtml2pdf/reportlab_paragraph.py", line 152, in _centerDrawParaLine
    tx._textOut(" ".join(words), 1)
TypeError: sequence item 0: expected str instance, bytes found
```