### PR TITLE
Fix "'NotImplementedType' object is not iterable" in py3

### DIFF
--- a/xhtml2pdf/w3c/cssParser.py
+++ b/xhtml2pdf/w3c/cssParser.py
@@ -1189,7 +1189,7 @@ class CSSParser(object):
             strres = tuple(filter(None, result.groups()))
             if strres:
                 try:
-                    strres = strres[0]
+                    strres = list(strres)[0]
                 except Exception:
                     strres = result.groups()[0]
             else:


### PR DESCRIPTION
TypeError: 'filter' object is not subscriptable