### PR TITLE
Update html5lib dependency version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Pillow>=2.0.0
 coverage
-html5lib==1.0b10
+html5lib>=1.0
 httplib2==0.7.6
 nose==1.3.3
 pyPdf2==1.26
@@ -8,4 +8,3 @@ reportlab>=3.0
 six
 Sphinx==1.4.8
 sphinx-rtd-theme==0.1.9
-

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     maintainer_email="luisza14@gmail.com",
     url="http://github.com/xhtml2pdf/xhtml2pdf",
     keywords="PDF, HTML, XHTML, XML, CSS",
-    install_requires=["html5lib==1.0b10", "httplib2", "pyPdf2", "Pillow", "reportlab>=3.0", "six"],
+    install_requires=["html5lib>=1.0", "httplib2", "pyPdf2", "Pillow", "reportlab>=3.0", "six"],
     setup_requires=["nose>=1.0"],
     include_package_data=True,
     packages=find_packages(exclude=["tests", "tests.*"]),

--- a/tox.appveyor.ini
+++ b/tox.appveyor.ini
@@ -12,7 +12,7 @@ commands =
 deps =
     Pillow>=2.0
     coverage
-    html5lib==1.0b10
+    html5lib>=1.0
     httplib2
     nose
     pyPdf2

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ commands =
 deps =
     Pillow>=2.0
     coverage
-    html5lib==1.0b10
+    html5lib>=1.0
     httplib2
     nose
     pyPdf2


### PR DESCRIPTION
This solves the issue of dependency conflicts with other packages and xhtml2pdf seems to work fine with all versions 1.x+. This is to fix issue #390 .