### PR TITLE
Fix for loading remote pdf files from Google App Engine env

### DIFF
--- a/xhtml2pdf/util.py
+++ b/xhtml2pdf/util.py
@@ -649,7 +649,7 @@ class pisaFileObject:
                         self.file = gzip.GzipFile(
                             mode="rb", fileobj=six.StringIO(r1.read()))
                     else:
-                        self.file = r1
+                        self.file = pisaTempFile(r1.read())
                 else:
                     log.debug(
                         "Received non-200 status: {}".format((r1.status, r1.reason)))


### PR DESCRIPTION
Fix for the error
google.appengine.dist27.gae_override.httplib.HTTPResponse instance has no attribute 'seek'

"PyPDF2/pdf.py", line 1689, in read
    stream.seek(-1, 2)