### PR TITLE
Allow for URI-escaped strings in base64 src data

### DIFF
--- a/xhtml2pdf/util.py
+++ b/xhtml2pdf/util.py
@@ -32,6 +32,11 @@ try:
 except ImportError:
     import urlparse
 
+try:
+    from urllib.parse import unquote as urllib_unquote
+except ImportError:
+    from urllib import unquote as urllib_unquote
+
 # Copyright 2010 Dirk Holtwick, holtwick.it
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -594,7 +599,8 @@ class pisaFileObject:
         if uri.startswith("data:"):
             m = _rx_datauri.match(uri)
             self.mimetype = m.group("mime")
-            self.data = base64.b64decode(m.group("data").encode("utf-8"))
+            b64 = urllib_unquote(m.group("data")).encode("utf-8")
+            self.data = base64.b64decode(b64)
 
         else:
             # Check if we have an external scheme


### PR DESCRIPTION
Some software produces HTML containing tags that specify their data in base64, but URI-escaped (which is a bad idea, but it nonetheless happens). That is to say, the '+' character is replaced by '%2B'.

The usual result is the exception 'binascii.Error: Incorrect padding' being thrown, or if the padding is correct by chance, the converted data is corrupted.