### PR TITLE
Render following pages, when only first has a background.

### DIFF
--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -19,7 +19,7 @@ HTML_CONTENT = """<!DOCTYPE html>
 </head>
 <body>
     <div>
-        <h1> Hello, world! </div>
+        <h1> Hello, world! </h1>
 
         <p>
             The quick red fox jumps over the lazy brown dog.
@@ -130,6 +130,29 @@ def test_document_background_image():
         # Identity the 'denker_transparent.png' image by its height and width, and make sure it's there.
         denker_transparant = [obj for obj in objects if obj['/Height'] == 137 and obj['/Width'] == 70]
         tools.assert_equal(len(denker_transparant), 1)
+
+
+def test_document_background_image_not_on_all_pages():
+    """
+    Test that all pages are being rendered, when background is a pdf file and it's applied for the first page only.
+    """
+    tests_folder = os.path.dirname(os.path.realpath(__file__))
+    background_path = os.path.join(tests_folder, 'samples', 'images.pdf')
+
+    css = "<style>@page {{background-image: url({background_location});}} @page two {{}}</style>".format(
+        background_location=background_path)
+
+    extra_html = """<pdf:nexttemplate name="two"> <pdf:nextpage> <p>Hello, world!</p>"""
+
+    with tempfile.TemporaryFile() as pdf_file:
+        pisaDocument(
+            src=io.StringIO(HTML_CONTENT.format(head=css, extra_html=extra_html)),
+            dest=pdf_file
+        )
+        pdf_file.seek(0)
+        pdf_reader = PdfFileReader(pdf_file)
+
+        tools.assert_equal(pdf_reader.getNumPages(), 2)
 
 
 @skip_if(IN_PYPY, "This doesn't work in pypy")

--- a/xhtml2pdf/xhtml2pdf_reportlab.py
+++ b/xhtml2pdf/xhtml2pdf_reportlab.py
@@ -249,13 +249,12 @@ class PmlPageTemplate(PageTemplate):
                 else:
                     pisaBackground = self.pisaBackground
 
-            if pisaBackground:
-                self.pisaBackgroundList.append(pisaBackground)
-            else:
-                if self.isPortrait():
-                    canvas.drawImage(self.img, 0, self.ph - self.h, self.w, self.h)
-                elif self.isLandscape():
-                    canvas.drawImage(self.img, 0, 0, self.w, self.h)
+            self.pisaBackgroundList.append(pisaBackground)
+
+            if self.isPortrait():
+                canvas.drawImage(self.img, 0, self.ph - self.h, self.w, self.h)
+            elif self.isLandscape():
+                canvas.drawImage(self.img, 0, 0, self.w, self.h)
 
             def pageNumbering(objList):
                 for obj in flatten(objList):


### PR DESCRIPTION
Added `pisaBackground` to `pisaBackgroundList`, even if it’s `None`.

`xhtml2pdf/document.py:140` generates page for every item in `context.pisaBackgroundList`.

 When a template has a background only on the first page, the following pages have `pisaBackground` of `None`, but they also should get rendered.

See issue #426