### PR TITLE
Two small fixes

### DIFF
--- a/xhtml2pdf/util.py
+++ b/xhtml2pdf/util.py
@@ -675,6 +675,8 @@ class pisaFileObject:
 
                 # Local data
                 if basepath:
+                    if sys.platform == 'win32' and os.path.isfile(basepath):
+                        basepath = os.path.dirname(basepath)
                     uri = os.path.normpath(os.path.join(basepath, uri))
 
                 if os.path.isfile(uri):

--- a/xhtml2pdf/w3c/cssParser.py
+++ b/xhtml2pdf/w3c/cssParser.py
@@ -363,7 +363,7 @@ class CSSParser(object):
         re_class = re.compile(i_class, _reflags)
         i_hash = '#((?:%s)+)' % i_nmchar
         re_hash = re.compile(i_hash, _reflags)
-        i_rgbcolor = '(#%s{6}|#%s{3})' % (i_hex, i_hex)
+        i_rgbcolor = '(#%s{68}|#%s{6}|#%s{3})' % (i_hex, i_hex, i_hex)
         re_rgbcolor = re.compile(i_rgbcolor, _reflags)
         i_nl = '\n|\r\n|\r|\f'
         i_escape_nl = '\\\\(?:%s)' % i_nl

--- a/xhtml2pdf/w3c/cssParser.py
+++ b/xhtml2pdf/w3c/cssParser.py
@@ -363,7 +363,7 @@ class CSSParser(object):
         re_class = re.compile(i_class, _reflags)
         i_hash = '#((?:%s)+)' % i_nmchar
         re_hash = re.compile(i_hash, _reflags)
-        i_rgbcolor = '(#%s{68}|#%s{6}|#%s{3})' % (i_hex, i_hex, i_hex)
+        i_rgbcolor = '(#%s{8}|#%s{6}|#%s{3})' % (i_hex, i_hex, i_hex)
         re_rgbcolor = re.compile(i_rgbcolor, _reflags)
         i_nl = '\n|\r\n|\r|\f'
         i_escape_nl = '\\\\(?:%s)' % i_nl


### PR DESCRIPTION
I'd like to propose two small changes.
- fix in util.py to support work with files in win32 environment.
- change regexp in w3c/cssParser.py to support defining color in hex format #rrggbbaa.