### PR TITLE
fix: use html.escape instead of cgi.escape (fix: #443)

### DIFF
--- a/setup_version.py
+++ b/setup_version.py
@@ -18,10 +18,17 @@
 Updates the version infos
 """
 
+from __future__ import absolute_import
+
 import time
 import re
 import cgi
+import six
 
+if not six.PY2:
+    from html import escape as html_escape
+else:
+    from cgi import escape as html_escape
 
 VERSION = open("VERSION.txt", "r").read().strip()
 BUILD = time.strftime("%Y-%m-%d")
@@ -33,7 +40,7 @@ FILES = [
     "doc/pisa-en.html",
 ]
 try:
-    HELP = cgi.escape(open("HELP.txt", "r").read(), 1)
+    HELP = html_escape(open("HELP.txt", "r").read(), 1)
 except:
     HELP = ""
 HELP = "<!--HELP--><pre>" + HELP + "</pre><!--HELP-->"

--- a/setup_version.py
+++ b/setup_version.py
@@ -18,8 +18,6 @@
 Updates the version infos
 """
 
-from __future__ import absolute_import
-
 import time
 import re
 import cgi

--- a/xhtml2pdf/document.py
+++ b/xhtml2pdf/document.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 import io
 
 from xhtml2pdf.context import pisaContext

--- a/xhtml2pdf/document.py
+++ b/xhtml2pdf/document.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
 import io
 
 from xhtml2pdf.context import pisaContext
@@ -10,6 +11,12 @@ from xhtml2pdf.xhtml2pdf_reportlab import PmlBaseDoc, PmlPageTemplate
 from xhtml2pdf.util import pisaTempFile, getBox, PyPDF2
 import cgi
 import logging
+import six
+
+if not six.PY2:
+    from html import escape as html_escape
+else:
+    from cgi import escape as html_escape
 
 # Copyright 2010 Dirk Holtwick, holtwick.it
 #
@@ -33,12 +40,14 @@ def pisaErrorDocument(dest, c):
     out.write("<p style='background-color:red;'><strong>%d error(s) occured:</strong><p>" % c.err)
     for mode, line, msg, _ in c.log:
         if mode == "error":
-            out.write("<pre>%s in line %d: %s</pre>" % (mode, line, cgi.escape(msg)))
+            out.write("<pre>%s in line %d: %s</pre>" %
+                      (mode, line, html_escape(msg)))
 
     out.write("<p><strong>%d warning(s) occured:</strong><p>" % c.warn)
     for mode, line, msg, _ in c.log:
         if mode == "warning":
-            out.write("<p>%s in line %d: %s</p>" % (mode, line, cgi.escape(msg)))
+            out.write("<p>%s in line %d: %s</p>" %
+                      (mode, line, html_escape(msg)))
 
     return pisaDocument(out.getvalue(), dest, raise_exception=False)
 

--- a/xhtml2pdf/xhtml2pdf_reportlab.py
+++ b/xhtml2pdf/xhtml2pdf_reportlab.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
 from hashlib import md5
 from reportlab.lib.enums import TA_RIGHT
 from reportlab.lib.styles import ParagraphStyle

--- a/xhtml2pdf/xhtml2pdf_reportlab.py
+++ b/xhtml2pdf/xhtml2pdf_reportlab.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from hashlib import md5
 from reportlab.lib.enums import TA_RIGHT
 from reportlab.lib.styles import ParagraphStyle
@@ -42,6 +43,11 @@ except:
         import Image as PILImage
     except:
         PILImage = None
+
+if not six.PY2:
+    from html import escape as html_escape
+else:
+    from cgi import escape as html_escape
 
 log = logging.getLogger("xhtml2pdf")
 
@@ -119,7 +125,7 @@ class PmlBaseDoc(BaseDocTemplate):
         if getattr(flowable, "outline", False):
             self.notify('TOCEntry', (
                 flowable.outlineLevel,
-                cgi.escape(copy.deepcopy(flowable.text), 1),
+                html_escape(copy.deepcopy(flowable.text), 1),
                 self.page))
 
     def handle_nextPageTemplate(self, pt):
@@ -150,7 +156,7 @@ class PmlBaseDoc(BaseDocTemplate):
             #collect the refs to the template objects, complain if any are bad
             c = PTCycle()
             for ptn in pt:
-            #special case name used to short circuit the iteration
+                #special case name used to short circuit the iteration
                 if ptn == '*':
                     c._restart = len(c)
                     continue


### PR DESCRIPTION
Fixes #443

```
 /home/travis/virtualenv/python3.7.3/lib/python3.7/site-packages/xhtml2pdf/xhtml2pdf_reportlab.py:122: DeprecationWarning: cgi.escape is deprecated, use html.escape instead
    cgi.escape(copy.deepcopy(flowable.text), 1),
```