### PR TITLE
Fixed padding problem

### DIFF
--- a/xhtml2pdf/util.py
+++ b/xhtml2pdf/util.py
@@ -603,6 +603,7 @@ class pisaFileObject:
             m = _rx_datauri.match(uri)
             self.mimetype = m.group("mime")
             b64 = urllib_unquote(m.group("data")).encode("utf-8")
+            b64 += b"=" * ((4 - len(b64) % 4) % 4)
             self.data = base64.b64decode(b64)
 
         else:


### PR DESCRIPTION
This patch fixes padding of the base64 data, in case the length of the data needs this. At least python3.7 base64.b64decode throws an error whenever the padding is incorrect.