### PR TITLE
replace deprecated urllib splithost function

### DIFF
--- a/xhtml2pdf/util.py
+++ b/xhtml2pdf/util.py
@@ -651,7 +651,10 @@ class pisaFileObject:
                 #mimetype = getMimeType(path)
 
                 # Using HTTPLIB
-                server, path = urllib2.splithost(uri[uri.find("//"):])
+                url_splitted = urlparse.urlsplit(uri)
+                server = url_splitted[1]
+                path = url_splitted[2]
+                path += "?" + url_splitted[3] if url_splitted[3] else ""
                 if uri.startswith("https://"):
                     conn = httplib.HTTPSConnection(server,  **httpConfig)
                 else:


### PR DESCRIPTION
Fixes #456 

Actual PR removes use of semi-public function `splithost` of urllib module.