### PR TITLE
in pisaFileObject, use isinstance instead of type to detect if uri is a string

### DIFF
--- a/xhtml2pdf/util.py
+++ b/xhtml2pdf/util.py
@@ -595,7 +595,7 @@ class pisaFileObject:
         self.local = None
         self.tmp_file = None
         uri = uri or str()
-        if type(uri) != str:
+        if not isinstance(uri, str):
             uri = uri.decode("utf-8")
         log.debug("FileObject %r, Basepath: %r", uri, basepath)
 


### PR DESCRIPTION
Solves issue #459.

I have tried running the unit tests, but I haven't been able, and haven't seen any documentation about how to do it.