### PR TITLE
Prevent border left color being set to False

### DIFF
--- a/xhtml2pdf/parser.py
+++ b/xhtml2pdf/parser.py
@@ -581,7 +581,7 @@ def pisaLoop(node, context, path=None, **kw):
                         (
                             ("keepWithNext", "-pdf-keep-with-next"),
                             ("outline", "-pdf-outline"),
-                            ("borderLeftColor", "-pdf-outline-open"),
+                            #("borderLeftColor", "-pdf-outline-open"),
                         ),
                         context.cssAttr,
                         getBool


### PR DESCRIPTION
When the border left style is set, the color is set based on the -pdf-outline-open attribute, which generally results in a False. The reportlab writer considers this an invalid color and the conversion raises an Exception.
Resolves #466 