### PR TITLE
Update usage.rst

### DIFF
--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -62,7 +62,7 @@ that converts relative URLs to absolute system paths.
         # use short variable names
         s_url = settings.STATIC_URL      # Typically /static/
         s_root = settings.STATIC_ROOT    # Typically /home/userX/project_static/
-        m_url = settings.MEDIA_URL       # Typically /static/media/
+        m_url = settings.MEDIA_URL       # Typically /media/
         m_root = settings.MEDIA_ROOT     # Typically /home/userX/project_static/media/
     
         # convert URIs to absolute system paths


### PR DESCRIPTION
This comment have bad recommendation:

`m_url = settings.MEDIA_URL       # Typically /static/media/ `

In settings.py:

`MEDIA_URL = "/static/media/"`

Because django cant serve media inside static, the recommendation need to be:

`m_url = settings.MEDIA_URL       # Typically /media/`

In settings.py:

`MEDIA_URL = "/media/"`