### PR TITLE
Fix Readthedocs url

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,7 @@ Documentation?
 xhtml2pdf has some documentation, and we could use your help improving it.
 A good place to start is ``doc/usage.rst``.
 
-Or also see in `Readthedocs <http://xhtml2pdf.readthedocs.io//>`__
+Or also see in `Readthedocs <http://xhtml2pdf.readthedocs.io/>`__
 
 
 Call for testing


### PR DESCRIPTION
Removed extra trailing slash from readthedocs url which caused 404 error