### PR TITLE
Fix typo in usage.rst

### DIFF
--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -25,7 +25,7 @@ Using with Python standalone
         # close output file
         result_file.close()                 # close output file
 
-        # return True on success and False on errors
+        # return False on success and True on errors
         return pisa_status.err
 
     # Main program


### PR DESCRIPTION
This fixes the comment which is currently incorrect. pisa_status.err is a count of the errors and when 0 Python interprets this as False, and when greater than 0 Python interprets it as True, so I swapped the True and False around in the comment to reflect this.