### PR TITLE
Add support for multiple fonts and unicode

### DIFF
--- a/xhtml2pdf/context.py
+++ b/xhtml2pdf/context.py
@@ -163,18 +163,22 @@ class pisaCSSBuilder(css.CSSBuilder):
         # The "src" attribute can be a CSS group but in that case
         # ignore everything except the font URI
         uri = data['src']
-        if not isinstance(data['src'], str):
-            for part in uri:
-                if isinstance(part, str):
-                    uri = part
-                    break
+        fonts = []
 
-        src = self.c.getFile(uri, relative=self.c.cssParser.rootPath)
-        self.c.loadFont(
-            names,
-            src,
-            bold=bold,
-            italic=italic)
+        if isinstance(data['src'], list):
+            for part in uri:
+                if isinstance(part, str) or isinstance(part, unicode):
+                    fonts.append(part)
+        else:
+            fonts.append(uri)
+
+        for font in fonts:
+            src = self.c.getFile(font, relative=self.c.cssParser.rootPath)
+            self.c.loadFont(
+                names,
+                src,
+                bold=bold,
+                italic=italic)
         return {}, {}
 
     def _pisaAddFrame(self, name, data, first=False, border=None, size=(0, 0)):

--- a/xhtml2pdf/context.py
+++ b/xhtml2pdf/context.py
@@ -4,25 +4,26 @@ import logging
 import os
 import re
 
+import six
+
 import reportlab
+import xhtml2pdf.default
+import xhtml2pdf.parser
 from reportlab.lib.enums import TA_LEFT
 from reportlab.lib.fonts import addMapping
-from reportlab.lib.pagesizes import landscape, A4
+from reportlab.lib.pagesizes import A4, landscape
 from reportlab.lib.styles import ParagraphStyle
 from reportlab.pdfbase import pdfmetrics
 from reportlab.pdfbase.ttfonts import TTFont
 from reportlab.platypus.frames import Frame, ShowBoundaryValue
 from reportlab.platypus.paraparser import ParaFrag, ps2tt, tt2ps
-import six
-
-import xhtml2pdf.default
-import xhtml2pdf.parser
-from xhtml2pdf.util import getSize, getCoords, getFile, pisaFileObject, \
-    getFrameDimensions, getColor, set_value, copy_attrs
+from xhtml2pdf.util import (copy_attrs, getColor, getCoords, getFile,
+                            getFrameDimensions, getSize, pisaFileObject,
+                            set_value)
 from xhtml2pdf.w3c import css
-from xhtml2pdf.xhtml2pdf_reportlab import PmlPageTemplate, PmlTableOfContents, \
-    PmlParagraph, PmlParagraphAndImage, PmlPageCount
-
+from xhtml2pdf.xhtml2pdf_reportlab import (PmlPageCount, PmlPageTemplate,
+                                           PmlParagraph, PmlParagraphAndImage,
+                                           PmlTableOfContents)
 
 TupleType = tuple
 ListType = list
@@ -167,7 +168,7 @@ class pisaCSSBuilder(css.CSSBuilder):
 
         if isinstance(data['src'], list):
             for part in uri:
-                if isinstance(part, str) or isinstance(part, unicode):
+                if isinstance(part, basestring):
                     fonts.append(part)
         else:
             fonts.append(uri)
@@ -199,7 +200,7 @@ class pisaCSSBuilder(css.CSSBuilder):
 
     def _getFromData(self, data, attr, default=None, func=None):
         if not func:
-            func = lambda x: x
+            def func(x): return x
 
         if type(attr) in (list, tuple):
             for a in attr:
@@ -393,7 +394,7 @@ class pisaCSSBuilder(css.CSSBuilder):
 class pisaCSSParser(css.CSSParser):
 
     def parseExternal(self, cssResourceName):
-        result=None
+        result = None
         oldRootPath = self.rootPath
         cssFile = self.c.getFile(cssResourceName, relative=self.rootPath)
         if not cssFile:


### PR DESCRIPTION
Hello!

This PR will fix the following issue:

https://github.com/xhtml2pdf/xhtml2pdf/issues/492

and will also include support for multiple font files being loaded, like the following scenarios



            @font-face {
                font-family: 'Medium';
                src: url('https://s3.amazonaws.com/static/path/fonts/myfont.woff');
            }

            @font-face {
                font-family: 'Regular';
                src: url('https://s3.amazonaws.com/static/path/fonts/myfont.woff') format('woff');
            }

            @font-face {
                font-family: 'Text-Medium';
                src: url('https://s3.amazonaws.com/static/path/fonts/myfont.woff') format('woff'), url('https://s3.amazonaws.com/static/path/fonts/myfont.ttf') format('truetype');
            }


Please let me know if you have any suggestions or remarks.

Thanks for the great project!