### PR TITLE
log.warn() depreciated - fixed

### DIFF
--- a/xhtml2pdf/context.py
+++ b/xhtml2pdf/context.py
@@ -155,7 +155,7 @@ class pisaCSSBuilder(css.CSSBuilder):
         fweight = str(data.get("font-weight", "normal")).lower()
         bold = fweight in ("bold", "bolder", "500", "600", "700", "800", "900")
         if not bold and fweight != "normal":
-            log.warn(
+            log.warning(
                 self.c.warning("@fontface, unknown value font-weight '%s'", fweight))
 
         # Font style
@@ -230,7 +230,7 @@ class pisaCSSBuilder(css.CSSBuilder):
                 pageBorder = data.get("-pdf-frame-border", None)
 
         if name in c.templateList:
-            log.warn(
+            log.warning(
                 self.c.warning("template '%s' has already been defined", name))
 
         if "-pdf-page-size" in data:
@@ -308,7 +308,7 @@ class pisaCSSBuilder(css.CSSBuilder):
                     fdata, c.pageSize[0], c.pageSize[1])
             x, y, w, h = getCoords(x, y, w, h, c.pageSize)
             if w <= 0 or h <= 0:
-                log.warn(
+                log.warning(
                     self.c.warning("Negative width or height of frame. Check @frame definitions."))
 
             frame = Frame(
@@ -334,13 +334,13 @@ class pisaCSSBuilder(css.CSSBuilder):
                 background, relative=self.c.cssParser.rootPath)
 
         if not frameList:
-            log.warn(
+            log.warning(
                 c.warning("missing explicit frame definition for content or just static frames"))
             fname, static, border, x, y, w, h, data = self._pisaAddFrame(name, data, first=True, border=pageBorder,
                                                                          size=c.pageSize)
             x, y, w, h = getCoords(x, y, w, h, c.pageSize)
             if w <= 0 or h <= 0:
-                log.warn(
+                log.warning(
                     c.warning("Negative width or height of frame. Check @page definitions."))
 
             if border or pageBorder:
@@ -804,17 +804,17 @@ class pisaContext(object):
                 nv = self.pathCallback(name, relative)
             else:
                 if path is None:
-                    log.warn(
+                    log.warning(
                         "Could not find main directory for getting filename. Use CWD")
                     path = os.getcwd()
                 nv = os.path.normpath(os.path.join(path, name))
                 if not (nv and os.path.isfile(nv)):
                     nv = None
             if nv is None:
-                log.warn(self.warning("File '%s' does not exist", name))
+                log.warning(self.warning("File '%s' does not exist", name))
             return nv
         except:
-            log.warn(
+            log.warning(
                 self.warning("getFile %r %r %r", name, relative, path), exc_info=1)
 
     def getFile(self, name, relative=None):
@@ -886,7 +886,7 @@ class pisaContext(object):
 
                 # check if font has already been registered
                 if fullFontName in self.fontList:
-                    log.warn(
+                    log.warning(
                         self.warning("Repeated font embed for %s, skip new embed ", fullFontName))
                 else:
 
@@ -926,7 +926,7 @@ class pisaContext(object):
 
                 # check if font has already been registered
                 if fullFontName in self.fontList:
-                    log.warn(
+                    log.warning(
                         self.warning("Repeated font embed for %s, skip new embed", fontName))
                 else:
 

--- a/xhtml2pdf/document.py
+++ b/xhtml2pdf/document.py
@@ -167,7 +167,7 @@ def pisaDocument(src, dest=None, path=None, link_callback=None, debug=0,
                         pagebg.mergePage(page)
                         page = pagebg
                     else:
-                        log.warn(context.warning(
+                        log.warning(context.warning(
                             "Background PDF %s doesn't exist.", bg))
                     output.addPage(page)
                     ctr += 1
@@ -177,7 +177,7 @@ def pisaDocument(src, dest=None, path=None, link_callback=None, debug=0,
                 # Found a background? So leave loop after first occurence
                 break
     else:
-        log.warn(context.warning("PyPDF2 not installed!"))
+        log.warning(context.warning("PyPDF2 not installed!"))
 
     # Get the resulting PDF and write it to the file object
     # passed from the caller

--- a/xhtml2pdf/tables.py
+++ b/xhtml2pdf/tables.py
@@ -177,7 +177,7 @@ class pisaTagTABLE(pisaTag):
         try:
             maxcols = max([len(row) for row in data] or [0])
         except ValueError:
-            log.warn(c.warning("<table> rows seem to be inconsistent"))
+            log.warning(c.warning("<table> rows seem to be inconsistent"))
             maxcols = [0]
 
         for i, row in enumerate(data):
@@ -206,7 +206,7 @@ class pisaTagTABLE(pisaTag):
             # t.hAlign = tdata.align
             c.addStory(t)
         else:
-            log.warn(c.warning("<table> is empty"))
+            log.warning(c.warning("<table> is empty"))
 
         # Cleanup and re-swap table data
         c.clearFrag()

--- a/xhtml2pdf/tags.py
+++ b/xhtml2pdf/tags.py
@@ -418,9 +418,9 @@ class pisaTagIMG(pisaTag):
                     c.fontSize = img.drawHeight
 
             except Exception:  # TODO: Kill catch-all
-                log.warn(c.warning("Error in handling image"), exc_info=1)
+                log.warning(c.warning("Error in handling image"), exc_info=1)
         else:
-            log.warn(c.warning("Need a valid file name!"))
+            log.warning(c.warning("Need a valid file name!"))
 
 
 class pisaTagHR(pisaTag):
@@ -620,13 +620,13 @@ class pisaTagPDFTEMPLATE(pisaTag):
         c.frameList = []
         c.frameStaticList = []
         if name in c.templateList:
-            log.warn(c.warning("template '%s' has already been defined", name))
+            log.warning(c.warning("template '%s' has already been defined", name))
 
     def end(self, c):
         attrs = self.attr
         name = attrs["name"]
         if len(c.frameList) <= 0:
-            log.warn(c.warning("missing frame definitions for template"))
+            log.warning(c.warning("missing frame definitions for template"))
 
         pt = PmlPageTemplate(
             id=name,

--- a/xhtml2pdf/util.py
+++ b/xhtml2pdf/util.py
@@ -334,11 +334,11 @@ def getSize(value, relative=0, base=None, default=0.0):
         try:
             value = float(value)
         except ValueError:
-            log.warn("getSize: Not a float %r", value)
+            log.warning("getSize: Not a float %r", value)
             return default  # value = 0
         return max(0, value)
     except Exception:
-        log.warn("getSize %r %r", original, relative, exc_info=1)
+        log.warning("getSize %r %r", original, relative, exc_info=1)
         return default
 
 
@@ -516,7 +516,7 @@ class pisaTempFile(object):
                 new_delegate.write(self.getvalue())
                 self._delegate = new_delegate
                 self.strategy = 1
-                log.warn("Created temporary file %s", self.name)
+                log.warning("Created temporary file %s", self.name)
             except:
                 self.capacity = - 1
 

--- a/xhtml2pdf/w3c/cssSpecial.py
+++ b/xhtml2pdf/w3c/cssSpecial.py
@@ -173,7 +173,7 @@ def splitBorder(parts):
     width = style = color = None
 
     if len(parts) > 3:
-        log.warn("To many elements for border style %r", parts)
+        log.warning("To many elements for border style %r", parts)
 
     for part in parts:
         # Width


### PR DESCRIPTION
Changed log.warn() to log.warning() as the .warn() method is depreciated since Python 3.3.

See: https://docs.python.org/3.8/library/logging.html