### PR TITLE
Fixed calculation of pagesize & orientation

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -11,7 +11,7 @@ Version 0.2.5
 * Update documentation (multiple typos were fixed)
 * Include Asian fonts support 
 * Allow Custom Font Name for ttf files.
-
+* @frame properties like width, right, bottom etc. are now correctly calculated depending on the page orientation (Fixes #499)
 
 Version 0.2.4
 -----------------

--- a/xhtml2pdf/context.py
+++ b/xhtml2pdf/context.py
@@ -11,7 +11,7 @@ import xhtml2pdf.default
 import xhtml2pdf.parser
 from reportlab.lib.enums import TA_LEFT
 from reportlab.lib.fonts import addMapping
-from reportlab.lib.pagesizes import A4, landscape
+from reportlab.lib.pagesizes import A4
 from reportlab.lib.styles import ParagraphStyle
 from reportlab.pdfbase import pdfmetrics
 from reportlab.pdfbase.ttfonts import TTFont
@@ -213,53 +213,13 @@ class pisaCSSBuilder(css.CSSBuilder):
                 return func(data[attr])
             return default
 
-    def atPage(self, name, pseudopage, declarations):
+    def atPage(self, name, pseudopage, data, isLandscape, pageBorder):
         c = self.c
-        data = {}
         name = name or "body"
-        pageBorder = None
-
-        if declarations:
-            result = self.ruleset([self.selector('*')], declarations)
-
-            if declarations:
-                try:
-                    data = result[0].values()[0]
-                except Exception:
-                    data = result[0].popitem()[1]
-                pageBorder = data.get("-pdf-frame-border", None)
 
         if name in c.templateList:
             log.warn(
                 self.c.warning("template '%s' has already been defined", name))
-
-        if "-pdf-page-size" in data:
-            c.pageSize = xhtml2pdf.default.PML_PAGESIZES.get(
-                str(data["-pdf-page-size"]).lower(), c.pageSize)
-
-        isLandscape = False
-        if "size" in data:
-            size = data["size"]
-            if type(size) is not ListType:
-                size = [size]
-            sizeList = []
-            for value in size:
-                valueStr = str(value).lower()
-                if type(value) is TupleType:
-                    sizeList.append(getSize(value))
-                elif valueStr == "landscape":
-                    isLandscape = True
-                elif valueStr == "portrait":
-                    isLandscape = False
-                elif valueStr in xhtml2pdf.default.PML_PAGESIZES:
-                    c.pageSize = xhtml2pdf.default.PML_PAGESIZES[valueStr]
-                else:
-                    raise RuntimeError("Unknown size value for @page")
-
-            if len(sizeList) == 2:
-                c.pageSize = tuple(sizeList)
-            if isLandscape:
-                c.pageSize = landscape(c.pageSize)
 
         padding_top = self._getFromData(data, 'padding-top', 0, getSize)
         padding_left = self._getFromData(data, 'padding-left', 0, getSize)

--- a/xhtml2pdf/w3c/cssParser.py
+++ b/xhtml2pdf/w3c/cssParser.py
@@ -17,7 +17,7 @@ from __future__ import unicode_literals
 
 import xhtml2pdf.default
 from xhtml2pdf.util import getSize
-from reportlab.lib.pagesizes import landscape, portrait
+from reportlab.lib.pagesizes import landscape
 
 try:
     from future_builtins import filter
@@ -751,6 +751,11 @@ class CSSParser(object):
             '{' S* declaration [ ';' S* declaration ]* '}' S*
         ;
         """
+
+        data = {}
+        pageBorder = None
+        isLandscape = False
+
         ctxsrc = src
         src = src[len('@page'):].lstrip()
         page, src = self._getIdent(src)

--- a/xhtml2pdf/w3c/cssParser.py
+++ b/xhtml2pdf/w3c/cssParser.py
@@ -15,6 +15,10 @@ from __future__ import absolute_import
 # Added by benjaoming to fix python3 tests
 from __future__ import unicode_literals
 
+import xhtml2pdf.default
+from xhtml2pdf.util import getSize
+from reportlab.lib.pagesizes import landscape, portrait
+
 try:
     from future_builtins import filter
 except ImportError:
@@ -778,9 +782,51 @@ class CSSParser(object):
             else:
                 src, nproperties = self._parseDeclarationGroup(src.lstrip(), braces=False)
                 properties += nproperties
+
+                # Set pagesize, orientation (landscape, portrait)
+                data = {}
+                pageBorder = None
+
+                if properties:
+                    result = self.cssBuilder.ruleset([self.cssBuilder.selector('*')], properties)
+                    try:
+                        data = result[0].values()[0]
+                    except Exception:
+                        data = result[0].popitem()[1]
+                    pageBorder = data.get("-pdf-frame-border", None)
+
+                if "-pdf-page-size" in data:
+                    self.c.pageSize = xhtml2pdf.default.PML_PAGESIZES.get(
+                        str(data["-pdf-page-size"]).lower(), self.c.pageSize)
+
+                isLandscape = False
+                if "size" in data:
+                    size = data["size"]
+                    if not isinstance(size, list):
+                        size = [size]
+                    sizeList = []
+                    for value in size:
+                        valueStr = str(value).lower()
+                        if isinstance(value, tuple):
+                            sizeList.append(getSize(value))
+                        elif valueStr == "landscape":
+                            isLandscape = True
+                        elif valueStr == "portrait":
+                            isLandscape = False
+                        elif valueStr in xhtml2pdf.default.PML_PAGESIZES:
+                            self.c.pageSize = xhtml2pdf.default.PML_PAGESIZES[valueStr]
+                        else:
+                            raise RuntimeError("Unknown size value for @page")
+
+                    if len(sizeList) == 2:
+                        self.c.pageSize = tuple(sizeList)
+
+                    if isLandscape:
+                        self.c.pageSize = landscape(self.c.pageSize)
+
             src = src.lstrip()
 
-        result = [self.cssBuilder.atPage(page, pseudopage, properties)]
+        result = [self.cssBuilder.atPage(page, pseudopage, data, isLandscape, pageBorder)]
 
         return src[1:].lstrip(), result
 


### PR DESCRIPTION
I've moved the calculation of the page size and page orientation.
Now they are being calculated BEFORE calculating the frames. This fixes issue #499 