### PR TITLE
Fixes issue #513 (issue with type 'basestring')

### DIFF
--- a/xhtml2pdf/context.py
+++ b/xhtml2pdf/context.py
@@ -28,6 +28,7 @@ from xhtml2pdf.xhtml2pdf_reportlab import (PmlPageCount, PmlPageTemplate,
 
 TupleType = tuple
 ListType = list
+basestring = six.text_type
 try:
     import urlparse
 except ImportError:


### PR DESCRIPTION
By simply adding the line "basestring = six.text_type" to context.py, we can make sure that the current version of xhtml2pdf is working with Python 3.0 and above.

The missing basestring definition was raising an error on Python 3.0+, as pointed out by #513. This is now fixed.