### PR TITLE
Fix letter spacing (#490)

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -11,6 +11,10 @@ Version 0.2.5
 * Update documentation (multiple typos were fixed)
 * Include Asian fonts support 
 * Allow Custom Font Name for ttf files.
+* Fixed letter-spacing CSS property. #490
+  "letter-spacing" now supports float values and relative and absolute units like "cm, in, em, %" etc.
+* Removed "i" and "inch" as unofficial synonyms for the "in" unit
+* "0.0" as value for a CSS property now acts the same way as "0" and "None"
 
 
 Version 0.2.4

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -115,10 +115,6 @@ class UtilsGetSizeTestCase(TestCase):
         res = getSize("1mm")
         self.assertEqual(res, 2.8346456692913385)
 
-    def test_get_size_for_i(self):
-        res = getSize("1i")
-        self.assertEqual(res, 72.00)
-
     def test_get_size_for_in(self):
         res = getSize("1in")
         self.assertEqual(res, 72.00)

--- a/xhtml2pdf/reportlab_paragraph.py
+++ b/xhtml2pdf/reportlab_paragraph.py
@@ -27,6 +27,7 @@ from reportlab.lib.enums import TA_LEFT, TA_RIGHT, TA_CENTER, TA_JUSTIFY
 from reportlab.lib.textsplit import ALL_CANNOT_START
 from copy import deepcopy
 from reportlab.lib.abag import ABag
+from xhtml2pdf.util import getSize
 
 
 PARAGRAPH_DEBUG = False
@@ -229,7 +230,8 @@ def _putFragLine(cur_x, tx, line):
 
     # Letter spacing
     if xs.style.letterSpacing != 'normal':
-        tx.setCharSpace(int(xs.style.letterSpacing))
+        letter_spacing = getSize("".join(xs.style.letterSpacing), line.fontSize)
+        tx.setCharSpace(letter_spacing)
 
     ws = getattr(tx, '_wordSpace', 0)
     nSpaces = 0

--- a/xhtml2pdf/util.py
+++ b/xhtml2pdf/util.py
@@ -292,8 +292,6 @@ def getSize(value, relative=0, base=None, default=0.0):
             return float(value[:-2].strip()) * mm  # 1mm = 0.1cm
         elif value[-2:] == 'in':
             return float(value[:-2].strip()) * inch  # 1pt == 1/72inch
-        elif value[-2:] == 'inch':
-            return float(value[:-4].strip()) * inch  # 1pt == 1/72inch
         elif value[-2:] == 'pt':
             return float(value[:-2].strip())
         elif value[-2:] == 'pc':
@@ -302,8 +300,6 @@ def getSize(value, relative=0, base=None, default=0.0):
             # XXX W3C says, use 96pdi
             # http://www.w3.org/TR/CSS21/syndata.html#length-units
             return float(value[:-2].strip()) * dpi96
-        elif value[-1:] == 'i':  # 1pt == 1/72inch
-            return float(value[:-1].strip()) * inch
         elif value in ("none", "0", "auto"):
             return 0.0
         elif relative:

--- a/xhtml2pdf/util.py
+++ b/xhtml2pdf/util.py
@@ -300,7 +300,7 @@ def getSize(value, relative=0, base=None, default=0.0):
             # XXX W3C says, use 96pdi
             # http://www.w3.org/TR/CSS21/syndata.html#length-units
             return float(value[:-2].strip()) * dpi96
-        elif value in ("none", "0", "auto"):
+        elif value in ("none", "0", '0.0', "auto"):
             return 0.0
         elif relative:
             if value[-3:] == 'rem':  # XXX


### PR DESCRIPTION
- The CSS-property 'letter-spacing' had some issues (see #490) and was only allowing integer values. So I fixed it by using the getSize() function instead. This now also adds support for relative and absolute units like "in, cm, px, pt, %, em" etc.

  I tested it a bit and the results look fine to me.
[Test_results_letter_spacing.pdf](https://github.com/xhtml2pdf/xhtml2pdf/files/5311203/Test_results_letter_spacing.pdf)


  ```
  <!DOCTYPE html>
  <html>
  <head>
  <style>
  @page {
                 size: a4 portrait;
                  @frame cont_frame1 {
                      left: 200pt;
                      right: 30pt;
                      bottom: 30pt;
                      top: 30pt;
                      -pdf-frame-border: 1
                  }}
  
  .test0 { letter-spacing: normal; }
  .test1 { letter-spacing: inherit; }
  .test2 { letter-spacing: 0; }
  .test3 { letter-spacing: 0.0; }
  .test4 { letter-spacing: 0.0cm; }
  .test5 { letter-spacing: 0cm; }
  .test6 { letter-spacing: 0mm; }
  .test7 { letter-spacing: 0in; }
  .test8 { letter-spacing: 0px; }
  .test9 { letter-spacing: 0pc; }
  .test10 { letter-spacing: 0%; }
  .test11 { letter-spacing: 0%; font-size: 17pt }
  .test12 { letter-spacing: 0em; }
  .test13 { letter-spacing: 0em; font-size: 17pt }
  
  .test14 { letter-spacing: 0.1cm; }
  .test15 { letter-spacing: 0.15cm; }
  .test16 { letter-spacing: 0.2cm; }
  .test17 { letter-spacing: 0.25cm; }
  .test18 { letter-spacing: 0.3cm; }
  .test19 { letter-spacing: 1cm; }
  .test20 { letter-spacing: 1.0cm; }
  .test21 { letter-spacing: 6mm; }
  .test22 { letter-spacing: 0.05in; }
  .test23 { letter-spacing: 11.5px; }
  .test24 { letter-spacing: 16.5pt; }
  .test25 { letter-spacing: 0.5pc; }
  .test26 { letter-spacing: 15%; }
  .test27 { letter-spacing: 15%; font-size: 17pt; }
  .test28 { letter-spacing: 1.5em; }
  .test29 { letter-spacing: 1.5em; font-size: 17pt }
  .test30 { letter-spacing: 1.5ex; }
  .test31 { letter-spacing: 1.5ex; font-size: 17pt; }
  .test32 { letter-spacing: 1.5rem; }
  .test33 { letter-spacing: 1.5rem; font-size: 17pt }
  
  .test34 { letter-spacing: -0.05cm; }
  .test35 { letter-spacing: -0.1cm; }
  .test36 { letter-spacing: -0.2cm; }
  .test37 { letter-spacing: -0.3cm; }
  .test38 { letter-spacing: -0.5cm; }
  .test39 { letter-spacing: -3mm; }
  .test40 { letter-spacing: -0.02in; }
  .test41 { letter-spacing: -0.5px; }
  .test42 { letter-spacing: -4pt; }
  .test43 { letter-spacing: -1.5pc; }
  .test44 { letter-spacing: -15%; }
  .test45 { letter-spacing: -15%; font-size: 17pt }
  .test46 { letter-spacing: -1.5em; }
  .test47 { letter-spacing: -1.5em; font-size: 17pt }
  .test48 { letter-spacing: -1.5ex; }
  .test49 { letter-spacing: -1.5ex; font-size: 17pt }
  .test50 { letter-spacing: -1.5rem; }
  .test51 { letter-spacing: -1.5rem; font-size: 17pt }
  
  .test52 { }
  
  </style>
  </head>
  <body>
  
  <p class="test0">Letter spacing</p>
  <p class="test1">Letter spacing</p>
  <p class="test2">Letter spacing</p>
  <p class="test3">Letter spacing</p>
  <p class="test4">Letter spacing</p>
  <p class="test5">Letter spacing</p>
  <p class="test6">Letter spacing</p>
  <p class="test7">Letter spacing</p>
  <p class="test8">Letter spacing</p>
  <p class="test9">Letter spacing</p>
  <p class="test10">Letter spacing</p>
  <p class="test11">Letter spacing</p>
  <p class="test12">Letter spacing</p>
  <p class="test13">Letter spacing</p>
  <p class="test14">Letter spacing</p>
  <p class="test15">Letter spacing</p>
  <p class="test16">Letter spacing</p>
  <p class="test17">Letter spacing</p>
  <p class="test18">Letter spacing</p>
  <p class="test19">Letter spacing</p>
  <p class="test20">Letter spacing</p>
  <p class="test21">Letter spacing</p>
  <p class="test22">Letter spacing</p>
  <p class="test23">Letter spacing</p>
  <p class="test24">Letter spacing</p>
  <p class="test25">Letter spacing</p>
  <p class="test26">Letter spacing</p>
  <p class="test27">Letter spacing</p>
  <p class="test28">Letter spacing</p>
  <p class="test29">Letter spacing</p>
  <p class="test30">Letter spacing</p>
  <p class="test31">Letter spacing</p>
  <p class="test32">Letter spacing</p>
  <p class="test33">Letter spacing</p>
  <p class="test34">Letter spacing</p>
  <p class="test35">Letter spacing</p>
  <p class="test36">Letter spacing</p>
  <p class="test37">Letter spacing</p>
  <p class="test38">Letter spacing</p>
  <p class="test39">Letter spacing</p>
  <p class="test40">Letter spacing</p>
  <p class="test41">Letter spacing</p>
  <p class="test42">Letter spacing</p>
  <p class="test43">Letter spacing</p>
  <p class="test44">Letter spacing</p>
  <p class="test45">Letter spacing</p>
  <p class="test46">Letter spacing</p>
  <p class="test47">Letter spacing</p>
  <p class="test48">Letter spacing</p>
  <p class="test49">Letter spacing</p>
  <p class="test50">Letter spacing</p>
  <p class="test51">Letter spacing</p>
  <p class="test52">Letter spacing</p>
  
  </body>
  </html>
  ```


- I also fixed the incorrect calculation in getSize() when entering "0.0" as value. "0.0" is now acting the same way as "0".

- And I removed 'inch' and 'i' as possible length units in getSize(). 'inch' wasn't even working and we already have 'in' as unit. Also 'inch' and 'i' aren't official units for CSS/HTML, only "in" is.