### PR TITLE
Use pikepdf instead of PyPDF2

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -11,6 +11,7 @@ Version 0.2.5
 * Update documentation (multiple typos were fixed)
 * Include Asian fonts support 
 * Allow Custom Font Name for ttf files.
+* Changed from PyPDF2 to pikepdf for testing, as PyPDF2 isn't maintained anymore since 2016
 
 
 Version 0.2.4

--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ The current release of xhtml2pdf is **xhtml2pdf 0.2.4**. As with all open-source
 About
 =====
 
-xhtml2pdf is a HTML to PDF converter using Python, the ReportLab Toolkit, html5lib and PyPDF2. It supports HTML5 and CSS 2.1 (and some of CSS 3). It is completely written in pure Python, so it is platform independent.
+xhtml2pdf is a HTML to PDF converter using Python, the ReportLab Toolkit, html5lib and pikepdf. It supports HTML5 and CSS 2.1 (and some of CSS 3). It is completely written in pure Python, so it is platform independent.
 
 The main benefit of this tool is that a user with web skills like HTML and CSS is able to generate PDF templates very quickly without learning new technologies.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ Pillow>=2.0.0
 coverage
 html5lib>=1.0
 nose==1.3.3
-pyPdf2==1.26
 reportlab>=3.0
 six
 Sphinx==1.4.8

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,8 @@ setup(
     maintainer_email="luisza14@gmail.com",
     url="http://github.com/xhtml2pdf/xhtml2pdf",
     keywords="PDF, HTML, XHTML, XML, CSS",
-    install_requires=["html5lib>=1.0", "pyPdf2", "Pillow", "reportlab>=3.0", "six","python-bidi==0.4.2","arabic-reshaper==2.1.0"],
+    install_requires=["html5lib>=1.0", "pikepdf>=1.19.3", "Pillow", "reportlab>=3.0", "six","python-bidi==0.4.2",
+                      "arabic-reshaper==2.1.0"],
     include_package_data=True,
     packages=find_packages(exclude=["tests", "tests.*"]),
     #    test_suite = "tests", They're not even working yet

--- a/tox.appveyor.ini
+++ b/tox.appveyor.ini
@@ -17,7 +17,7 @@ deps =
     coverage
     html5lib>=1.0
     nose
-    pyPdf2
+    pikepdf>=1.19.3
     rl32: reportlab>=3.2,<3.3
     rl33: reportlab>=3.3,<3.4
     rl34: reportlab>=3.4,<3.5

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ deps =
     coverage
     html5lib>=1.0
     nose
-    pyPdf2
+    pikepdf>=1.19.3
     rl30: reportlab>=3.3.0,<3.4.0
     rl31: reportlab>=3.4.0,<3.5.0
     rl32: reportlab>=3.5.0,<3.5.10

--- a/xhtml2pdf/document.py
+++ b/xhtml2pdf/document.py
@@ -7,7 +7,7 @@ from xhtml2pdf.parser import pisaParser
 from reportlab.platypus.flowables import Spacer
 from reportlab.platypus.frames import Frame
 from xhtml2pdf.xhtml2pdf_reportlab import PmlBaseDoc, PmlPageTemplate
-from xhtml2pdf.util import pisaTempFile, getBox, PyPDF2, arabic_format
+from xhtml2pdf.util import pisaTempFile, getBox, arabic_format
 import logging
 import six
 
@@ -144,40 +144,40 @@ def pisaDocument(src, dest=None, path=None, link_callback=None, debug=0,
     else:
         doc.build(context.story)
 
-    # Add watermarks
-    if PyPDF2:
-        for bgouter in context.pisaBackgroundList:
-            # If we have at least one background, then lets do it
-            if bgouter:
-                istream = out
-
-                output = PyPDF2.PdfFileWriter()
-                input1 = PyPDF2.PdfFileReader(istream)
-                ctr = 0
-                # TODO: Why do we loop over the same list again?
-                # see bgouter at line 137
-                for bg in context.pisaBackgroundList:
-                    page = input1.getPage(ctr)
-                    if (
-                            bg and not bg.notFound() and
-                            (bg.mimetype == "application/pdf")
-                    ):
-                        bginput = PyPDF2.PdfFileReader(bg.getFile())
-                        pagebg = bginput.getPage(0)
-                        pagebg.mergePage(page)
-                        page = pagebg
-                    else:
-                        log.warning(context.warning(
-                            "Background PDF %s doesn't exist.", bg))
-                    output.addPage(page)
-                    ctr += 1
-                out = pisaTempFile(capacity=context.capacity)
-                output.write(out)
-                # data = sout.getvalue()
-                # Found a background? So leave loop after first occurence
-                break
-    else:
-        log.warning(context.warning("PyPDF2 not installed!"))
+    # # Add watermarks
+    # if PyPDF2:
+    #     for bgouter in context.pisaBackgroundList:
+    #         # If we have at least one background, then lets do it
+    #         if bgouter:
+    #             istream = out
+    #
+    #             output = PyPDF2.PdfFileWriter()
+    #             input1 = PyPDF2.PdfFileReader(istream)
+    #             ctr = 0
+    #             # TODO: Why do we loop over the same list again?
+    #             # see bgouter at line 137
+    #             for bg in context.pisaBackgroundList:
+    #                 page = input1.getPage(ctr)
+    #                 if (
+    #                         bg and not bg.notFound() and
+    #                         (bg.mimetype == "application/pdf")
+    #                 ):
+    #                     bginput = PyPDF2.PdfFileReader(bg.getFile())
+    #                     pagebg = bginput.getPage(0)
+    #                     pagebg.mergePage(page)
+    #                     page = pagebg
+    #                 else:
+    #                     log.warning(context.warning(
+    #                         "Background PDF %s doesn't exist.", bg))
+    #                 output.addPage(page)
+    #                 ctr += 1
+    #             out = pisaTempFile(capacity=context.capacity)
+    #             output.write(out)
+    #             # data = sout.getvalue()
+    #             # Found a background? So leave loop after first occurence
+    #             break
+    # else:
+    #     log.warning(context.warning("PyPDF2 not installed!"))
 
     # Get the resulting PDF and write it to the file object
     # passed from the caller

--- a/xhtml2pdf/pdf.py
+++ b/xhtml2pdf/pdf.py
@@ -14,54 +14,54 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import six
-import logging
-
-
-from xhtml2pdf.util import pisaTempFile, getFile, PyPDF2
-
-
-log = logging.getLogger("xhtml2pdf")
-
-
-class pisaPDF:
-    def __init__(self, capacity=-1):
-        self.capacity = capacity
-        self.files = []
-
-    def addFromURI(self, url, basepath=None):
-        obj = getFile(url, basepath)
-        if obj and (not obj.notFound()):
-            self.files.append(obj.getFile())
-
-    addFromFileName = addFromURI
-
-    def addFromFile(self, f):
-        if hasattr(f, "read"):
-            self.files.append(f)
-        else:
-            self.addFromURI(f)
-
-    def addFromString(self, data):
-        self.files.append(pisaTempFile(data, capacity=self.capacity))
-
-    def addDocument(self, doc):
-        if hasattr(doc.dest, "read"):
-            self.files.append(doc.dest)
-
-    def join(self, file=None):
-        output = PyPDF2.PdfFileWriter()
-        for pdffile in self.files:
-            input = PyPDF2.PdfFileReader(pdffile)
-            for pageNumber in six.moves.range(input.getNumPages()):
-                output.addPage(input.getPage(pageNumber))
-
-        if file is not None:
-            output.write(file)
-            return file
-        out = pisaTempFile(capacity=self.capacity)
-        output.write(out)
-        return out.getvalue()
-
-    getvalue = join
-    __str__ = join
+# import six
+# import logging
+#
+#
+# from xhtml2pdf.util import pisaTempFile, getFile, PyPDF2
+#
+#
+# log = logging.getLogger("xhtml2pdf")
+#
+#
+# class pisaPDF:
+#     def __init__(self, capacity=-1):
+#         self.capacity = capacity
+#         self.files = []
+#
+#     def addFromURI(self, url, basepath=None):
+#         obj = getFile(url, basepath)
+#         if obj and (not obj.notFound()):
+#             self.files.append(obj.getFile())
+#
+#     addFromFileName = addFromURI
+#
+#     def addFromFile(self, f):
+#         if hasattr(f, "read"):
+#             self.files.append(f)
+#         else:
+#             self.addFromURI(f)
+#
+#     def addFromString(self, data):
+#         self.files.append(pisaTempFile(data, capacity=self.capacity))
+#
+#     def addDocument(self, doc):
+#         if hasattr(doc.dest, "read"):
+#             self.files.append(doc.dest)
+#
+#     def join(self, file=None):
+#         output = PyPDF2.PdfFileWriter()
+#         for pdffile in self.files:
+#             input = PyPDF2.PdfFileReader(pdffile)
+#             for pageNumber in six.moves.range(input.getNumPages()):
+#                 output.addPage(input.getPage(pageNumber))
+#
+#         if file is not None:
+#             output.write(file)
+#             return file
+#         out = pisaTempFile(capacity=self.capacity)
+#         output.write(out)
+#         return out.getvalue()
+#
+#     getvalue = join
+#     __str__ = join

--- a/xhtml2pdf/util.py
+++ b/xhtml2pdf/util.py
@@ -68,11 +68,6 @@ if _reportlab_version < (2, 1):
 log = logging.getLogger("xhtml2pdf")
 
 try:
-    import PyPDF2
-except ImportError:
-    PyPDF2 = None
-
-try:
     from reportlab.graphics import renderPM
 except ImportError:
     renderPM = None


### PR DESCRIPTION
I'd like to submit this PR to suggest the use of pikepdf instead of PyPDF2.

**Reason:** PyPDF2 isn't maintained & outdated

**Benefits:** pikepdf has newer PDF & encryption standards and supports Python 3.5 to 3.8

PyPDF2 isn't maintained anymore since 2016 and only supports Python 2.6 to 3.5 (all outdated by now).
Right now we were only using PyPDF2 for testing, so there isn't really a need to change at the moment. BUT if we want to implement new features (such as encrypted PDFs suggested by #454) it would definitely be better to use pikepdf as it uses newer PDF and encryption standards than PyPDF2). More advantages can be found here: https://github.com/pikepdf/pikepdf