### PR TITLE
Fix attribute error when parsing list of fonts

### DIFF
--- a/xhtml2pdf/context.py
+++ b/xhtml2pdf/context.py
@@ -833,7 +833,7 @@ class pisaContext(object):
             src = file.uri
 
             log.debug("Load font %r", src)
-            if names.startswith("#"):
+            if isinstance(names, str) and names.startswith("#"):
                 names = names.strip('#')
             if type(names) is ListType:
                 fontAlias = names


### PR DESCRIPTION
When the list of fonts was passed in names arguments an error occurred 
`AttributeError 'list' object has no attribute 'startswith'`
