### PR TITLE
Renamed variables to avoid shadowing built-ins

### DIFF
--- a/testrender/testrender.py
+++ b/testrender/testrender.py
@@ -20,19 +20,15 @@ def render_pdf(filename, output_dir, options):
         print('Rendering %s' % filename)
     basename = os.path.basename(filename)
     outname = '%s.pdf' % os.path.splitext(basename)[0]
-    outfile = os.path.join(output_dir, outname)
-    input = open(filename, 'rb')
-    output = open(outfile, 'wb')
+    output_path = os.path.join(output_dir, outname)
 
-    result = pisa.pisaDocument(input, output, path=filename)
-
-    input.close()
-    output.close()
+    with open(filename, 'rb') as input_file, open(output_path, 'wb') as output_file:
+        result = pisa.pisaDocument(input_file, output_file, path=filename)
 
     if result.err:
         print('Error rendering %s: %s' % (filename, result.err))
         sys.exit(1)
-    return outfile
+    return output_path
 
 
 def convert_to_png(infile, output_dir, options):
@@ -141,17 +137,17 @@ def create_html_file(results, template_file, output_dir, options):
                     '<h2>Generated from <a href="../%(src)s/%(html)s" class="">%(html)s</a></h2>\n'
                     % {'pdf': pdfname, 'html':htmlname, 'src': options.source_dir})
         for i, page in enumerate(pages):
-            vars = dict(((k, os.path.basename(v)) for k,v in page.items()
-                         if k != 'diff_value'))
-            vars['page'] = i+1
+            variables = dict(((k, os.path.basename(v)) for k, v in page.items()
+                              if k != 'diff_value'))
+            variables['page'] = i + 1
             if 'diff' in page:
-                vars['diff_value'] = page['diff_value']
-                if vars['diff_value']:
-                    vars['class'] = 'result-page-diff error'
+                variables['diff_value'] = page['diff_value']
+                if variables['diff_value']:
+                    variables['class'] = 'result-page-diff error'
                 else:
                     if options.only_errors:
                         continue
-                    vars['class'] = 'result-page-diff'
+                    variables['class'] = 'result-page-diff'
                 html.append('<div class="%(class)s">\n'
                             '<h3>Page %(page)i</h3>\n'
 
@@ -174,7 +170,7 @@ def create_html_file(results, template_file, output_dir, options):
                             '<img src="%(ref_thumb)s"/></a>\n'
                             '</div>\n'
 
-                            '</div>\n' % vars)
+                            '</div>\n' % variables)
             else:
                 html.append('<div class="result-page">\n'
                            '<h3>Page %(page)i</h3>\n'
@@ -184,7 +180,7 @@ def create_html_file(results, template_file, output_dir, options):
                            '<img src="%(png_thumb)s"/></a>\n'
                            '</div>\n'
 
-                           '</div>\n' % vars)
+                           '</div>\n' % variables)
         html.append('</div>\n\n')
 
     now = datetime.datetime.now()

--- a/xhtml2pdf/pdf.py
+++ b/xhtml2pdf/pdf.py
@@ -51,9 +51,9 @@ class pisaPDF:
     def join(self, file=None):
         output = PyPDF2.PdfFileWriter()
         for pdffile in self.files:
-            input = PyPDF2.PdfFileReader(pdffile)
-            for pageNumber in six.moves.range(input.getNumPages()):
-                output.addPage(input.getPage(pageNumber))
+            pdf = PyPDF2.PdfFileReader(pdffile)
+            for pageNumber in six.moves.range(pdf.getNumPages()):
+                output.addPage(pdf.getPage(pageNumber))
 
         if file is not None:
             output.write(file)

--- a/xhtml2pdf/pisa.py
+++ b/xhtml2pdf/pisa.py
@@ -220,7 +220,7 @@ def execute():
     quiet = 0
     debug = 0
     tempdir = None
-    format = "pdf"
+    file_format = "pdf"
     css = None
     xhtml = None
     encoding = None
@@ -279,7 +279,7 @@ def execute():
 
         elif o in ("-t", "--format"):
             # Format XXX ???
-            format = a
+            file_format = a
 
         elif o in ("-b", "--base"):
             base_dir = a
@@ -358,14 +358,14 @@ def execute():
             dest_part = src
             if dest_part.lower().endswith(".html") or dest_part.lower().endswith(".htm"):
                 dest_part = ".".join(src.split(".")[:-1])
-            dest = dest_part + "." + format.lower()
+            dest = dest_part + "." + file_format.lower()
             for i in six.moves.range(10):
                 try:
                     open(dest, "wb").close()
                     break
                 except:
                     pass
-                dest = dest_part + "-%d.%s" % (i, format.lower())
+                dest = dest_part + "-%d.%s" % (i, file_format.lower())
         else:
             dest = a_dest
 
@@ -398,7 +398,7 @@ def execute():
             path=wpath,
             errout=sys.stdout,
             tempdir=tempdir,
-            format=format,
+            format=file_format,
             link_callback=lc,
             default_css=css,
             xhtml=xhtml,

--- a/xhtml2pdf/reportlab_paragraph.py
+++ b/xhtml2pdf/reportlab_paragraph.py
@@ -24,7 +24,6 @@ from reportlab.rl_settings import _FUZZ
 
 basestring = six.text_type
 unicode = six.text_type  # python 3
-str = six.text_type
 
 PARAGRAPH_DEBUG = False
 LEADING_FACTOR = 1.0

--- a/xhtml2pdf/w3c/cssParser.py
+++ b/xhtml2pdf/w3c/cssParser.py
@@ -490,8 +490,8 @@ class CSSParser(object):
             properties = []
             try:
                 for propertyName, src in six.iteritems(kwAttributes):
-                    src, property = self._parseDeclarationProperty(src.strip(), propertyName)
-                    properties.append(property)
+                    src, single_property = self._parseDeclarationProperty(src.strip(), propertyName)
+                    properties.append(single_property)
 
             except self.ParseError as err:
                 err.setFullCSSSource(src, inline=True)
@@ -1074,17 +1074,17 @@ class CSSParser(object):
         properties = []
         src = src.lstrip()
         while src[:1] not in ('', ',', '{', '}', '[', ']', '(', ')', '@'): # XXX @?
-            src, property = self._parseDeclaration(src)
+            src, single_property = self._parseDeclaration(src)
 
             # XXX Workaround for styles like "*font: smaller"
             if src.startswith("*"):
                 src = "-nothing-" + src[1:]
                 continue
 
-            if property is None:
+            if single_property is None:
                 src = src[1:].lstrip()
                 break
-            properties.append(property)
+            properties.append(single_property)
             if src.startswith(';'):
                 src = src[1:].lstrip()
             else:
@@ -1116,11 +1116,11 @@ class CSSParser(object):
                 # suppor a null transition, as well as an "=" transition
                 src = src[1:].lstrip()
 
-            src, property = self._parseDeclarationProperty(src, propertyName)
+            src, single_property = self._parseDeclarationProperty(src, propertyName)
         else:
-            property = None
+            single_property = None
 
-        return src, property
+        return src, single_property
 
 
     def _parseDeclarationProperty(self, src, propertyName):
@@ -1131,8 +1131,8 @@ class CSSParser(object):
         important, src = self._getMatchResult(self.re_important, src)
         src = src.lstrip()
 
-        property = self.cssBuilder.property(propertyName, expr, important)
-        return src, property
+        single_property = self.cssBuilder.property(propertyName, expr, important)
+        return src, single_property
 
 
     def _parseExpression(self, src, returnList=False):

--- a/xhtml2pdf/xhtml2pdf_reportlab.py
+++ b/xhtml2pdf/xhtml2pdf_reportlab.py
@@ -867,11 +867,11 @@ class PmlLeftPageBreak(CondPageBreak):
 
 
 class PmlInput(Flowable):
-    def __init__(self, name, type="text", width=10, height=10, default="",
+    def __init__(self, name, input_type="text", width=10, height=10, default="",
                  options=None):
         self.width = width
         self.height = height
-        self.type = type
+        self.type = input_type
         self.name = name
         self.default = default
         self.options = options if options is not None else []


### PR DESCRIPTION
Some variables in the code base were using the same name as some Python built-ins (input, type, property, format etc.). Therefore I've renamed them. This will avoid that maybe later we'll run into problems and some strange bugs.