### PR TITLE
Imagemagick warning fixed

### DIFF
--- a/testrender/testrender.py
+++ b/testrender/testrender.py
@@ -61,7 +61,7 @@ def create_diff_image(srcfile1, srcfile2, output_dir, options):
 
     outname = '%s.diff%s' % os.path.splitext(srcfile1)
     outfile = os.path.join(output_dir, outname)
-    _,result = exec_cmd(options, options.compare_cmd, '-metric', 'ae', srcfile1, srcfile2,'-lowlight-color','white', outfile)
+    _,result = exec_cmd(options, options.compare_cmd, '-metric', 'ae', srcfile1, srcfile2,'-lowlight-color','white',  '-colorspace', 'RGB', outfile)
     diff_value = int(float(result.strip()))
     if diff_value > 0:
         if not options.quiet:


### PR DESCRIPTION
As already mentioned in #524 , when using a newer version of Imagemagick (7.0.10.31 in my case), a warning is produced due to an invalid color space for grayscale png files. This won't allow to continue running the testrender.py file.

I found a solution [here](https://unix.stackexchange.com/questions/485292/rgb-color-space-not-permitted-on-grayscale), that suggests adding `-colorspace RGB` as additional parameter. It worked on my PC - there is no warning anymore and the testrender file is running just fine.

(The Travis Xenial image is still running Imagemagick 6.8.9.9 and is running without errors. So I guess this warning was introduced after later.)
