### PR TITLE
Fixed Resource Warnings

### DIFF
--- a/testrender/testrender.py
+++ b/testrender/testrender.py
@@ -61,7 +61,7 @@ def create_diff_image(srcfile1, srcfile2, output_dir, options):
 
     outname = '%s.diff%s' % os.path.splitext(srcfile1)
     outfile = os.path.join(output_dir, outname)
-    _,result = exec_cmd(options, options.compare_cmd, '-metric', 'ae', srcfile1, srcfile2,'-lowlight-color','white', outfile)
+    _,result = exec_cmd(options, options.compare_cmd, '-metric', 'ae', srcfile1, srcfile2,'-lowlight-color','white', "-colorspace", "RGB", outfile)
     diff_value = int(float(result.strip()))
     if diff_value > 0:
         if not options.quiet:

--- a/testrender/testrender.py
+++ b/testrender/testrender.py
@@ -61,7 +61,7 @@ def create_diff_image(srcfile1, srcfile2, output_dir, options):
 
     outname = '%s.diff%s' % os.path.splitext(srcfile1)
     outfile = os.path.join(output_dir, outname)
-    _,result = exec_cmd(options, options.compare_cmd, '-metric', 'ae', srcfile1, srcfile2,'-lowlight-color','white', "-colorspace", "RGB", outfile)
+    _,result = exec_cmd(options, options.compare_cmd, '-metric', 'ae', srcfile1, srcfile2,'-lowlight-color','white', outfile)
     diff_value = int(float(result.strip()))
     if diff_value > 0:
         if not options.quiet:

--- a/xhtml2pdf/document.py
+++ b/xhtml2pdf/document.py
@@ -146,6 +146,7 @@ def pisaDocument(src, dest=None, path=None, link_callback=None, debug=0,
 
     # Add watermarks
     if PyPDF2:
+        file_handler = None
         for bgouter in context.pisaBackgroundList:
             # If we have at least one background, then lets do it
             if bgouter:
@@ -162,10 +163,12 @@ def pisaDocument(src, dest=None, path=None, link_callback=None, debug=0,
                             bg and not bg.notFound() and
                             (bg.mimetype == "application/pdf")
                     ):
-                        bginput = PyPDF2.PdfFileReader(bg.getFile())
+                        file_handler = open(bg.uri, 'rb')
+                        bginput = PyPDF2.PdfFileReader(file_handler)
                         pagebg = bginput.getPage(0)
                         pagebg.mergePage(page)
                         page = pagebg
+
                     # Todo: the else-statement doesn't make a lot of sense to me; it's just throwing warnings
                     #  on unittesting \tests. Probably we have to rewrite the whole "background-image" stuff
                     #  to deal with cases like:
@@ -180,10 +183,14 @@ def pisaDocument(src, dest=None, path=None, link_callback=None, debug=0,
                     # else:
                     #     log.warning(context.warning(
                     #         "Background PDF %s doesn't exist.", bg))
+
                     output.addPage(page)
+
                     ctr += 1
                 out = pisaTempFile(capacity=context.capacity)
                 output.write(out)
+                if file_handler:
+                    file_handler.close()
                 # data = sout.getvalue()
                 # Found a background? So leave loop after first occurence
                 break

--- a/xhtml2pdf/pdf.py
+++ b/xhtml2pdf/pdf.py
@@ -31,7 +31,7 @@ class pisaPDF:
     def addFromURI(self, url, basepath=None):
         obj = getFile(url, basepath)
         if obj and (not obj.notFound()):
-            self.files.append(obj.getFile())
+            self.files.append(obj.getFileContent())
 
     addFromFileName = addFromURI
 

--- a/xhtml2pdf/pisa.py
+++ b/xhtml2pdf/pisa.py
@@ -151,15 +151,12 @@ class pisaLinkLoader:
             if new_suffix in (".css", ".gif", ".jpg", ".png"):
                 suffix = new_suffix
         path = tempfile.mktemp(prefix="pisa-", suffix=suffix)
-        ufile = urllib2.urlopen(url)
-        tfile = open(path, "wb")
-        while True:
-            data = ufile.read(1024)
-            if not data:
-                break
-            tfile.write(data)
-        ufile.close()
-        tfile.close()
+        with urllib2.urlopen(url) as ufile, open(path, "wb") as tfile:
+            while True:
+                data = ufile.read(1024)
+                if not data:
+                    break
+                tfile.write(data)
         self.tfileList.append(path)
 
         if not self.quiet:
@@ -290,7 +287,8 @@ def execute():
 
         elif o in ("-c", "--css"):
             # CSS
-            css = open(a, "r").read()
+            with open(a, "r") as file_handler:
+                css = file_handler.read()
 
         elif o in ("--css-dump",):
             # CSS dump
@@ -348,11 +346,12 @@ def execute():
         else:
             if src.startswith("http:") or src.startswith("https:"):
                 wpath = src
-                fsrc = getFile(src).getFile()
+                fsrc = getFile(src).getFileContent()
                 src = "".join(urlparse.urlsplit(src)[1:3]).replace("/", "-")
             else:
                 fsrc = wpath = os.path.abspath(src)
-                fsrc = open(fsrc, "rb")
+                with open(fsrc, "rb") as file_handler:
+                    fsrc = file_handler.read()
 
         if a_dest is None:
             dest_part = src
@@ -471,7 +470,8 @@ def makeDataURI(data=None, mimetype=None, filename=None):
 
 
 def makeDataURIFromFile(filename):
-    data = open(filename, "rb").read()
+    with open(filename, "rb") as file_handler:
+        data = file_handler.read()
     return makeDataURI(data, filename=filename)
 
 

--- a/xhtml2pdf/util.py
+++ b/xhtml2pdf/util.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import base64
+import io
 import logging
 import mimetypes
 import os.path
@@ -45,6 +46,7 @@ except ImportError:
 try:
     import urllib.request as urllib2
 except ImportError:
+    import urllib2
     import urllib2
 
 try:
@@ -592,7 +594,7 @@ class pisaFileObject:
 
         self.basepath = basepath
         self.mimetype = None
-        self.file = None
+        self.file_content = None
         self.data = None
         self.uri = None
         self.local = None
@@ -638,7 +640,7 @@ class pisaFileObject:
                 self.mimetype = urlResponse.info().get(
                     "Content-Type", '').split(";")[0]
                 self.uri = urlResponse.geturl()
-                self.file = urlResponse
+                self.file_content = urlResponse.read()
 
             # Drive letters have len==1 but we are looking
             # for things like http:
@@ -675,10 +677,10 @@ class pisaFileObject:
                     if r1.getheader("content-encoding") == "gzip":
                         import gzip
 
-                        self.file = gzip.GzipFile(
+                        self.file_content = gzip.GzipFile(
                             mode="rb", fileobj=six.BytesIO(r1.read()))
                     else:
-                        self.file = pisaTempFile(r1.read())
+                        self.file_content = pisaTempFile(r1.read())
                 else:
                     log.debug(
                         "Received non-200 status: {}".format((r1.status, r1.reason)))
@@ -690,7 +692,7 @@ class pisaFileObject:
                     self.mimetype = urlResponse.info().get(
                         "Content-Type", '').split(";")[0]
                     self.uri = urlResponse.geturl()
-                    self.file = urlResponse
+                    self.file_content = urlResponse.read()
                 conn.close()
 
             else:
@@ -709,16 +711,19 @@ class pisaFileObject:
 
                     self.setMimeTypeByName(uri)
                     if self.mimetype and self.mimetype.startswith('text'):
-                        self.file = open(uri, "r") #removed bytes... lets hope it goes ok :/
+                        with open(uri, "r") as file_handler:
+                            # removed bytes... lets hope it goes ok :/
+                            self.file_content = file_handler.read()
                     else:
-                        # removed bytes... lets hope it goes ok :/
-                        self.file = open(uri, "rb")
+                        with open(uri, "rb") as file_handler:
+                            # removed bytes... lets hope it goes ok :/
+                            self.file_content = file_handler.read()
 
-    def getFile(self):
-        if self.file is not None:
-            return self.file
-        if self.data is not None:
-            return pisaTempFile(self.data)
+    def getFileContent(self):
+        if self.file_content is not None:
+            return self.file_content
+        if self.data is not None:  # BUG: Not working right now
+            return self.data
         return None
 
     def getNamedFile(self):
@@ -728,8 +733,9 @@ class pisaFileObject:
             return str(self.local)
         if not self.tmp_file:
             self.tmp_file = tempfile.NamedTemporaryFile()
-            if self.file:
-                shutil.copyfileobj(self.file, self.tmp_file)
+            if self.file_content:
+                with io.StringIO(self.file_content) as file_handler:
+                    shutil.copyfileobj(file_handler, self.tmp_file)
             else:
                 self.tmp_file.write(self.getData())
             self.tmp_file.flush()
@@ -738,20 +744,20 @@ class pisaFileObject:
     def getData(self):
         if self.data is not None:
             return self.data
-        if self.file is not None:
-            try:
-                self.data = self.file.read()
-            except:
-                if self.mimetype and self.mimetype.startswith('text'):
-                    self.file = open(self.file.name, "rb") #removed bytes... lets hope it goes ok :/
-                    self.data = self.file.read().decode('utf-8')
-                else:
-                    raise
-            return self.data
+        if self.file_content is not None:
+            # try:
+            #     self.data = self.file_content
+            # except:
+            #     if self.mimetype and self.mimetype.startswith('text'):
+            #         self.file = open(self.file.name, "rb") #removed bytes... lets hope it goes ok :/
+            #         self.data = self.file.read().decode('utf-8')
+            #     else:
+            #         raise
+            return self.file_content
         return None
 
     def notFound(self):
-        return (self.file is None) and (self.data is None)
+        return (self.file_content is None) and (self.data is None)
 
     def setMimeTypeByName(self, name):
         " Guess the mime type "

--- a/xhtml2pdf/util.py
+++ b/xhtml2pdf/util.py
@@ -722,7 +722,7 @@ class pisaFileObject:
     def getFileContent(self):
         if self.file_content is not None:
             return self.file_content
-        if self.data is not None:  # BUG: Not working right now
+        if self.data is not None:
             return self.data
         return None
 

--- a/xhtml2pdf/util.py
+++ b/xhtml2pdf/util.py
@@ -47,7 +47,6 @@ try:
     import urllib.request as urllib2
 except ImportError:
     import urllib2
-    import urllib2
 
 try:
     import urllib.parse as urlparse

--- a/xhtml2pdf/w3c/css.py
+++ b/xhtml2pdf/w3c/css.py
@@ -1005,10 +1005,7 @@ class CSSParser(cssParser.CSSParser):
     def createCSSBuilder(self, **kw):
         return self.CSSBuilderFactory(**kw)
 
-
     def parseExternal(self, cssResourceName):
         if os.path.isfile(cssResourceName):
-            cssFile = open(cssResourceName, 'r')
-            return self.parseFile(cssFile, True)
+            return self.parseFile(cssResourceName)
         raise RuntimeError("Cannot resolve external CSS file: \"%s\"" % cssResourceName)
-

--- a/xhtml2pdf/w3c/cssParser.py
+++ b/xhtml2pdf/w3c/cssParser.py
@@ -426,17 +426,14 @@ class CSSParser(object):
     # ~ Public CSS Parsing API
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-    def parseFile(self, srcFile, closeFile=False):
+    def parseFile(self, srcFile):
         """Parses CSS file-like objects using the current cssBuilder.
         Use for external stylesheets."""
 
-        try:
-            result = self.parse(srcFile.read())
-        finally:
-            if closeFile:
-                srcFile.close()
-        return result
+        with open(srcFile, "r") as file_handler:
+            file_content = file_handler.read()
 
+        return self.parse(file_content)
 
     def parse(self, src):
         """Parses CSS string source using the current cssBuilder.

--- a/xhtml2pdf/xhtml2pdf_reportlab.py
+++ b/xhtml2pdf/xhtml2pdf_reportlab.py
@@ -313,7 +313,7 @@ class PmlImageReader(object):  # TODO We need a factory here, returning either a
             self._image = fileName
             self.fp = getattr(fileName, 'fp', None)
             try:
-                self.fileName = self._image.fileName
+                self.fileName = fileName
             except AttributeError:
                 self.fileName = 'PILIMAGE_%d' % id(self)
         else:
@@ -346,6 +346,7 @@ class PmlImageReader(object):  # TODO We need a factory here, returning either a
                         self._image = self._read_image(self.fp)
                     if getattr(self._image, 'format', None) == 'JPEG':
                         self.jpeg_fh = self._jpeg_fh
+                        # BUG: add self.fp.close()
                 else:
                     from reportlab.pdfbase.pdfutils import readJPEGInfo
 
@@ -357,6 +358,7 @@ class PmlImageReader(object):  # TODO We need a factory here, returning either a
                     self._data = self.fp.read()
                     self._dataA = None
                     self.fp.seek(0)
+                    # BUG: add self.fp.close()
             except:  # TODO: Kill the catch-all
                 et, ev, tb = sys.exc_info()
                 if hasattr(ev, 'args'):

--- a/xhtml2pdf/xhtml2pdf_reportlab.py
+++ b/xhtml2pdf/xhtml2pdf_reportlab.py
@@ -346,7 +346,6 @@ class PmlImageReader(object):  # TODO We need a factory here, returning either a
                         self._image = self._read_image(self.fp)
                     if getattr(self._image, 'format', None) == 'JPEG':
                         self.jpeg_fh = self._jpeg_fh
-                        # BUG: add self.fp.close()
                 else:
                     from reportlab.pdfbase.pdfutils import readJPEGInfo
 
@@ -358,7 +357,6 @@ class PmlImageReader(object):  # TODO We need a factory here, returning either a
                     self._data = self.fp.read()
                     self._dataA = None
                     self.fp.seek(0)
-                    # BUG: add self.fp.close()
             except:  # TODO: Kill the catch-all
                 et, ev, tb = sys.exc_info()
                 if hasattr(ev, 'args'):

--- a/xhtml2pdf/xhtml2pdf_reportlab.py
+++ b/xhtml2pdf/xhtml2pdf_reportlab.py
@@ -228,7 +228,7 @@ class PmlPageTemplate(PageTemplate):
                 if self.pisaBackground.mimetype.startswith("image/"):
 
                     try:
-                        self.img = PmlImageReader(six.BytesIO(self.pisaBackground.getData().getvalue()))
+                        self.img = PmlImageReader(six.BytesIO(self.pisaBackground.getData()))
                         iw, ih = self.img.getSize()
                         pw, self.ph = canvas._pagesize
 

--- a/xhtml2pdf/xhtml2pdf_reportlab.py
+++ b/xhtml2pdf/xhtml2pdf_reportlab.py
@@ -228,7 +228,7 @@ class PmlPageTemplate(PageTemplate):
                 if self.pisaBackground.mimetype.startswith("image/"):
 
                     try:
-                        self.img = PmlImageReader(six.BytesIO(self.pisaBackground.getData()))
+                        self.img = PmlImageReader(six.BytesIO(self.pisaBackground.getData().getvalue()))
                         iw, ih = self.img.getSize()
                         pw, self.ph = canvas._pagesize
 


### PR DESCRIPTION
While running the unit tests, Python was showing several Resource Warnings. This was due to opening fonts, background images, images etc. without closing the files afterwards or closing them a lot later:

```
ResourceWarning: unclosed file <_io.BufferedReader name='E:\\TEMP\\xhtml2pdf\\git\\tests\\samples\\img\\denker-transparent.png'> [css.py:378]
ResourceWarning: unclosed file <_io.BufferedReader name='E:\\TEMP\\xhtml2pdf\\git\\tests\\samples\\img\\denker-transparent.png'> [parser.py:687]
ResourceWarning: unclosed file <_io.BufferedReader name='E:\\TEMP\\xhtml2pdf\\git\\tests\\samples\\img\\denker.png'> [parser.py:687]
ResourceWarning: unclosed file <_io.BufferedReader name='E:\\TEMP\\xhtml2pdf\\git\\tests\\samples\\font\\Arabic_font\\MarkaziText-Regular.ttf'> [cssParser.py:851]
ResourceWarning: unclosed file <_io.BufferedReader name='E:\\TEMP\\xhtml2pdf\\git\\tests\\samples\\font\\Arabic_font\\MarkaziText-Medium.ttf'> [cssParser.py:851]
ResourceWarning: unclosed file <_io.BufferedReader name='E:\\TEMP\\xhtml2pdf\\git\\tests\\samples\\font\\Arabic_font\\MarkaziText-Bold.ttf'> [cssParser.py:851]
ResourceWarning: unclosed file <_io.BufferedReader name='E:\\TEMP\\xhtml2pdf\\git\\tests\\samples\\font\\Arabic_font\\MarkaziText-SemiBold.ttf'> [cssParser.py:851]
ResourceWarning: unclosed file <_io.BufferedReader name='E:\\TEMP\\xhtml2pdf\\git\\tests\\samples\\font\\Arabic_font\\MarkaziText-VariableFont_wght.ttf'> [cssParser.py:851]
ResourceWarning: unclosed file <_io.BufferedReader name='E:\\TEMP\\xhtml2pdf\\git\\tests\\samples\\font\\Noto_Sans\\NotoSans-Regular.ttf'> [cssParser.py:851]
ResourceWarning: unclosed file <_io.BufferedReader name='E:\\TEMP\\xhtml2pdf\\git\\tests\\samples\\font\\Noto_Sans\\NotoSans-Bold.ttf'> [cssParser.py:851]
ResourceWarning: unclosed file <_io.BufferedReader name='E:\\TEMP\\xhtml2pdf\\git\\tests\\samples\\font\\Noto_Sans\\NotoSans-Italic.ttf'> [cssParser.py:851]
ResourceWarning: unclosed file <_io.BufferedReader name='E:\\TEMP\\xhtml2pdf\\git\\tests\\samples\\font\\Noto_Sans\\NotoSans-BoldItalic.ttf'> [cssParser.py:851]

Ran 161 tests in 1.858s

OK
```

This PR fixes this problem. Files are now opened in a context manager (with-statement), which makes sure that they'll be closed automatically later.

Sometimes files were opened, transferred through several functions and then the content was read a lot later. So I've changed it and now the content is read at first and then the content is transferred instead of the opened file.

We're not testing for memory usage, but this should reduce the memory usage of xhtml2pdf at least a bit.