### PR TITLE
Upgrade Pillow due to high severity vulnerability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 arabic-reshaper>=2.1.0
 coverage>=5.3
 html5lib>=1.1
-Pillow>=7.2.0
+Pillow>=8.1.1
 pyPdf2>=1.26.0
 python-bidi>=0.4.2
 reportlab>=3.5.53


### PR DESCRIPTION
# Background
Pillow before 8.1.1 allows attackers to cause a denial of service (memory consumption) because the reported size of a contained image is not properly checked for an ICO container, and thus an attempted memory allocation can be very large.

# Modifications
Upgrade Pillow to 8.1.1+