### PR TITLE
SVG support when svglib available

### DIFF
--- a/xhtml2pdf/reportlab_paragraph.py
+++ b/xhtml2pdf/reportlab_paragraph.py
@@ -246,7 +246,7 @@ def _putFragLine(cur_x, tx, line):
                     txfs = xs.style.fontSize
                 iy0, iy1 = imgVRange(h, cbDefn.valign, txfs)
                 cur_x_s = cur_x + nSpaces * ws
-                drawing = cbDefn.image.getVector(w, h)
+                drawing = cbDefn.image.getDrawing(w, h)
                 if drawing:
                     renderPDF.draw(drawing, tx._canvas, cur_x_s, cur_y + iy0)
                 else:

--- a/xhtml2pdf/reportlab_paragraph.py
+++ b/xhtml2pdf/reportlab_paragraph.py
@@ -13,6 +13,7 @@ from operator import truth
 from string import whitespace
 
 import six
+from reportlab.graphics import renderPDF
 from reportlab.lib.abag import ABag
 from reportlab.lib.colors import Color
 from reportlab.lib.enums import TA_CENTER, TA_JUSTIFY, TA_LEFT, TA_RIGHT
@@ -243,7 +244,11 @@ def _putFragLine(cur_x, tx, line):
                     txfs = xs.style.fontSize
                 iy0, iy1 = imgVRange(h, cbDefn.valign, txfs)
                 cur_x_s = cur_x + nSpaces * ws
-                tx._canvas.drawImage(cbDefn.image.getImage(), cur_x_s, cur_y + iy0, w, h, mask='auto')
+                drawing = cbDefn.image.getVector(w, h)
+                if drawing:
+                    renderPDF.draw(drawing, tx._canvas, cur_x_s, cur_y + iy0)
+                else:
+                    tx._canvas.drawImage(cbDefn.image.getImage(), cur_x_s, cur_y + iy0, w, h, mask='auto')
                 cur_x += w
                 cur_x_s += w
                 setXPos(tx, cur_x_s - tx._x0)
@@ -661,7 +666,7 @@ _scheme_re = re.compile('^[a-zA-Z][-+a-zA-Z0-9]+$')
 
 def _doLink(tx, link, rect):
     if six.PY2:
-        link = six.text_type(link, 'utf8') 
+        link = six.text_type(link, 'utf8')
     parts = link.split(':', 1)
     scheme = len(parts) == 2 and parts[0].lower() or ''
     if _scheme_re.match(scheme) and scheme != 'document':
@@ -1270,7 +1275,7 @@ class Paragraph(Flowable):
                         nText = six.text_type(w[1][1], 'utf-8')
                     else:
                         nText = w[1][1]
-                        
+
                     if nText: n += 1
                     fontSize = f.fontSize
                     if calcBounds:
@@ -1544,7 +1549,7 @@ class Paragraph(Flowable):
 
                 #now the font for the rest of the paragraph
                 tx.setFont(f.fontName, f.fontSize, leading)
-                ws = getattr(tx, '_wordSpace', 0)  
+                ws = getattr(tx, '_wordSpace', 0)
                 t_off = dpl(tx, offset, ws, lines[0][1], noJustifyLast and nLines == 1)
                 if (hasattr(f, 'underline') and f.underline) or f.link or (hasattr(f, 'strike') and f.strike):
                     xs = tx.XtraState = ABag()
@@ -1727,7 +1732,7 @@ if __name__ == '__main__':    # NORUNTESTS
             print()
             l += 1
 
-    from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
+    from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
     from reportlab.lib.units import cm
 
     TESTS = sys.argv[1:]

--- a/xhtml2pdf/reportlab_paragraph.py
+++ b/xhtml2pdf/reportlab_paragraph.py
@@ -23,6 +23,8 @@ from reportlab.platypus.flowables import Flowable
 from reportlab.platypus.paraparser import ParaParser
 from reportlab.rl_settings import _FUZZ
 
+from xhtml2pdf.util import getSize
+
 basestring = six.text_type
 unicode = six.text_type  # python 3
 
@@ -226,7 +228,7 @@ def _putFragLine(cur_x, tx, line):
 
     # Letter spacing
     if xs.style.letterSpacing != 'normal':
-        tx.setCharSpace(int(xs.style.letterSpacing))
+        tx.setCharSpace(getSize("".join(xs.style.letterSpacing)))
 
     ws = getattr(tx, '_wordSpace', 0)
     nSpaces = 0

--- a/xhtml2pdf/xhtml2pdf_reportlab.py
+++ b/xhtml2pdf/xhtml2pdf_reportlab.py
@@ -35,7 +35,7 @@ from reportlab.platypus.tables import Table, TableStyle
 from reportlab.rl_config import register_reset
 
 from xhtml2pdf.reportlab_paragraph import Paragraph
-from xhtml2pdf.util import getBorderStyle, getUID
+from xhtml2pdf.util import getBorderStyle, getUID, pisaTempFile
 
 try:
     import PIL.Image as PILImage
@@ -490,7 +490,7 @@ class PmlImage(Flowable, PmlMaxHeightMixIn):
         self.kw = kw
         self.hAlign = 'CENTER'
         self._mask = mask
-        self._imgdata = data
+        self._imgdata = data.getvalue() if isinstance(data, pisaTempFile) else data
         # print "###", repr(data)
         self.mimetype = mimetype
 

--- a/xhtml2pdf/xhtml2pdf_reportlab.py
+++ b/xhtml2pdf/xhtml2pdf_reportlab.py
@@ -21,7 +21,6 @@ from hashlib import md5
 
 import reportlab.pdfbase.pdfform as pdfform
 import six
-import svglib
 from reportlab.lib.enums import TA_RIGHT
 from reportlab.lib.styles import ParagraphStyle
 from reportlab.lib.utils import (LazyImageReader, flatten, getStringIO,


### PR DESCRIPTION
Addresses https://github.com/xhtml2pdf/xhtml2pdf/issues/73.

Adds support for SVGs if `svglib` is present.

**Changes**
- Added `PmlImage.getDrawing()` to return a ReportLabs Drawing
- Updated `reportlab_paragraph._putFragLine` to render image Drawing if available instead of the raster image
- Added `PmlImage.getDrawingRaster()` to rasterise a Drawing
  - **Note:** only used for backwards compatibility with `getImage()`
- Fixed `tuple` passed to `setCharSpace` when style.letterSpacing is (amount, unit)
- Fixed `BytesIO` passed `pisaTempFile` rather than `bytes` when `pisaTempFile` passed to `PmlImage`