### PR TITLE
Keep tests quieter

### DIFF
--- a/tests/test_table_css.py
+++ b/tests/test_table_css.py
@@ -69,9 +69,19 @@ class TableTest(TestCase):
         </html>
         """
 
-        context = pisaParser(BytesIO(html.encode('utf-8')), pisaContext(None))
+        with self.assertLogs("xhtml2pdf", level="DEBUG") as cm:
+            context = pisaParser(BytesIO(html.encode("utf-8")), pisaContext(None))
 
-        self.assertEqual(context.story, [], "Empty table doesn't return an empty story!")
+            self.assertEqual(
+                context.story, [], "Empty table doesn't return an empty story!"
+            )
+            self.assertEqual(
+                cm.output,
+                [
+                    "DEBUG:xhtml2pdf:Col widths: []",
+                    "WARNING:xhtml2pdf:<table> is empty\n'<table> </table>'",
+                ],
+            )
 
     def test_tr_background_color(self):
         """

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -291,7 +291,7 @@ class PisaTagTableTestCase(TestCase):
 
     def setUp(self):
         self.element = self._getElement("rootElement")
-        self.attrs = AttrContainer({"border": "", "bordercolor": "", "cellpadding": "", "align": "", "repeat": "", "width": ""})
+        self.attrs = AttrContainer({"border": "", "bordercolor": "", "cellpadding": "", "align": "", "repeat": "", "width": None})
 
     def _getElement(self, tagName, body="filler"):
         dom = minidom.parseString("<{}>{}</{}>".format(tagName, body, tagName))


### PR DESCRIPTION
- Asserts for one intentional warning on empty tables
- Fixes width to "None" to avoid another warning where an empty string
  results in a warning

Thought I'd start with a simpler PR before #560

This currently breaks on Python 2.7 (which will get dropped with #582 anyway)

Before:

```
python -m unittest discover
.............................................................................<table> is empty
'<table> </table>'
.......getSize: Not a float ''
................................................................................
----------------------------------------------------------------------
Ran 164 tests in 0.656s

OK
```

After:

```
python -m unittest discover
....................................................................................................................................................................
----------------------------------------------------------------------
Ran 164 tests in 0.655s

OK
```