### PR TITLE
Fix UnboundLocalError in reportlab_paragraph (#585)

### DIFF
--- a/tests/samples/nested_table.html
+++ b/tests/samples/nested_table.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+		<title>Nested Table</title>
+		<style type="text/css">
+body {
+	color: #003366;
+	background-color: #FFFFFF;
+	font-family: Verdana, Tahoma, sans-serif;
+	font-size: 11px;
+}
+
+table {
+	line-height: 10pt;
+	width: 100%;
+}
+
+th {
+	background-color: #ffd700;
+	padding: 0.1cm 0cm 0cm 0cm;
+	-pdf-word-wrap: CJK;
+}
+
+td {
+	padding: 0.1cm 0cm 0cm 0cm;
+	vertical-align: top;
+	background-color: #ffffcc;
+	-pdf-word-wrap: CJK;
+}
+</style>
+	</head>
+	<body>
+		<div>
+			<table border="1" width="100%">
+				<thead>
+					<tr>
+						<th>Column A</th>
+						<th>Column B</th>
+						<th>Column C</th>
+						<th>Column D</th>
+						<th>Column E</th>
+						<th>Column F</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td>Value A</td>
+						<td>Value B</td>
+						<td></td>
+						<td></td>
+						<td>
+							<ul>
+								<li>
+									<table border="1" width="100%">
+										<thead>
+											<tr>
+												<th>Column 1</th>
+												<th>Column 2</th>
+												<th>Column 3</th>
+												<th>Column 4</th>
+											</tr>
+										</thead>
+										<tbody>
+											<tr>
+												<td>Value 1</td>
+												<td>Value 2</td>
+												<td></td>
+												<td>
+													Here is a sentence that is fifty-four characters long.
+													100 Hello WORLD, H.W.
+												</td>
+											</tr>
+										</tbody>
+									</table>
+								</li>
+							</ul>
+						</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+	</body>
+</html>

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -154,6 +154,26 @@ class DocumentTest(TestCase):
 
             self.assertEqual(pdf_reader.getNumPages(), 2)
 
+    def test_document_nested_table(self):
+        """
+        Test that nested tables are being rendered.
+        """
+        tests_folder = os.path.dirname(os.path.realpath(__file__))
+        html_path = os.path.join(tests_folder, 'samples', 'nested_table.html')
+
+        with open(html_path) as html_file:
+            html = html_file.read()
+
+        with tempfile.TemporaryFile() as pdf_file:
+            pisaDocument(
+                src=io.StringIO(html),
+                dest=pdf_file
+            )
+            pdf_file.seek(0)
+            pdf_reader = PdfFileReader(pdf_file)
+            self.assertEqual(pdf_reader.getNumPages(), 1)
+
+
     @skipIf(IN_PYPY, "This doesn't work in pypy")
     def test_document_creation_without_metadata(self):
         with tempfile.TemporaryFile() as pdf_file:

--- a/xhtml2pdf/reportlab_paragraph.py
+++ b/xhtml2pdf/reportlab_paragraph.py
@@ -363,7 +363,7 @@ def _putFragLine(cur_x, tx, line):
 
     # XXX Modified for XHTML2PDF
     # Backcolor
-    if hasattr(f, "backColor"):
+    if words and hasattr(f, "backColor"):
         if xs.backgroundColor is not None:
             xs.backgrounds.append((xs.background_x, cur_x_s, xs.backgroundColor, xs.backgroundFontSize))
 


### PR DESCRIPTION
Fixes `UnboundLocalError: local variable 'f' referenced before assignment` error in reportlab_paragraph.py (#585)

Tested by adding unit test and running `nosetests --with-coverage`