### PR TITLE
Pinning reportlab lower than 3.6.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ html5lib>=1.1
 Pillow>=8.1.1
 PyPDF3>=1.0.5
 python-bidi>=0.4.2
-reportlab>=3.5.53
+reportlab<3.6.7
 Sphinx>=3.2.1
 sphinx-rtd-theme>=0.5.0
 svglib>=1.2.1

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     url="http://github.com/xhtml2pdf/xhtml2pdf",
     keywords="PDF, HTML, XHTML, XML, CSS",
     install_requires=["html5lib>=1.0.1", "PyPDF3>=1.0.5", "Pillow>=8.1.1",
-                      "reportlab>=3.5.53", "svglib>=1.2.1",
+                      "reportlab<3.6.7", "svglib>=1.2.1",
                       "python-bidi>=0.4.2", "arabic-reshaper>=2.1.0"],
     include_package_data=True,
     packages=find_packages(exclude=["tests", "tests.*"]),

--- a/tox.appveyor.ini
+++ b/tox.appveyor.ini
@@ -27,4 +27,4 @@ deps =
     rl3530: reportlab>=3.5.30,<3.5.50
     rl3550: reportlab>=3.5.50,<=3.5.68
     rl360: reportlab>3.6.0,<3.6.5
-    rl365: reportlab>=3.6.5
+    rl365: reportlab>=3.6.5,<3.6.7

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ deps =
     Pillow>=8.1.1
     PyPDF3>=1.0.5
     python-bidi>=0.4.2
-    reportlab>=3.5.53
+    reportlab<3.6.7
     svglib>=1.2.1
 [testenv:develop]
 deps = -rrequirements.txt


### PR DESCRIPTION
As flagged in #591 version `reportlab` 3.6.7 drops support getBytesIO and getStringIO meaning we have an import error in `xhtml2pdf_reportlab.py`:

```
  File "/usr/local/lib/python3.7/site-packages/xhtml2pdf/pisa.py", line 19, in <module>
    from xhtml2pdf.document import pisaDocument
  File "/usr/local/lib/python3.7/site-packages/xhtml2pdf/document.py", line 4, in <module>
    from xhtml2pdf.context import pisaContext
  File "/usr/local/lib/python3.7/site-packages/xhtml2pdf/context.py", line 11, in <module>
    import xhtml2pdf.parser
  File "/usr/local/lib/python3.7/site-packages/xhtml2pdf/parser.py", line 32, in <module>
    from xhtml2pdf.tables import *  # TODO: Kill wild import!
  File "/usr/local/lib/python3.7/site-packages/xhtml2pdf/tables.py", line 8, in <module>
    from xhtml2pdf.tags import pisaTag
  File "/usr/local/lib/python3.7/site-packages/xhtml2pdf/tags.py", line 10, in <module>
    from xhtml2pdf import xhtml2pdf_reportlab
  File "/usr/local/lib/python3.7/site-packages/xhtml2pdf/xhtml2pdf_reportlab.py", line 20, in <module>
    from reportlab.lib.utils import flatten, open_for_read, getStringIO, \
ImportError: cannot import name 'getStringIO' from 'reportlab.lib.utils' 
```

I've changed the `reportlab` dependency to be less than 3.6.7 to stop this from happening.