### PR TITLE
reportlab "getStringIO undefined" version problem

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ html5lib>=1.1
 Pillow>=8.1.1
 PyPDF3>=1.0.5
 python-bidi>=0.4.2
-reportlab>=3.5.53
+reportlab==3.5.53
 Sphinx>=3.2.1
 sphinx-rtd-theme>=0.5.0
 svglib>=1.2.1


### PR DESCRIPTION
FYI: from reportlab's recent changes: they decided to delete **getStringIO** and **getStringBytes** methods.

Please see this changelog of their project: 
https://hg.reportlab.com/hg-public/reportlab/summary


Last weekend our project failed by some mysteries reasons mentioned below.
So 

```
reportlab==3.5.53
``` 

this line might be temporary solution for this situation.
