### PR TITLE
Fix color invalid

### DIFF
--- a/xhtml2pdf/parser.py
+++ b/xhtml2pdf/parser.py
@@ -330,9 +330,9 @@ def lower(sequence):
 def CSS2Frag(c, kw, isBlock):
     # COLORS
     if "color" in c.cssAttr:
-        c.frag.textColor = getColor(c.cssAttr["color"])
+        c.frag.textColor = getColor(c.cssAttr["color"], "#000000")
     if "background-color" in c.cssAttr:
-        c.frag.backColor = getColor(c.cssAttr["background-color"])
+        c.frag.backColor = getColor(c.cssAttr["background-color"], "#ffffff")
         # FONT SIZE, STYLE, WEIGHT
     if "font-family" in c.cssAttr:
         c.frag.fontName = c.getFontName(c.cssAttr["font-family"])

--- a/xhtml2pdf/w3c/css.py
+++ b/xhtml2pdf/w3c/css.py
@@ -573,7 +573,7 @@ class CSSSelectorCombinationQualifier(CSSSelectorQualifierBase):
 class CSSTerminalFunction(object):
     def __init__(self, name, params):
         self.name = name
-        self.params = params
+        self.params = [param if isinstance(param, str) else str(param) for param in params]
 
     def __repr__(self):
         return '<CSS function: %s(%s)>' % (self.name, ', '.join(self.params))


### PR DESCRIPTION
This pull request is intended to fix an error generated by invalid or unsupported css.

Input value that generated the error:

```html
<div style="background-color: hsl(0,0%,100%)">
  <p style="color: hsl(0,0%,0%)"> Text </p>
</div>
```

Error generated 

```
  File "/usr/local/lib/python3.9/site-packages/xhtml2pdf/parser.py", line 576, in pisaLoop
    CSS2Frag(context, kw, isBlock)
  File "/usr/local/lib/python3.9/site-packages/xhtml2pdf/parser.py", line 292, in CSS2Frag
    c.frag.textColor = getColor(c.cssAttr["color"])
  File "/usr/local/lib/python3.9/site-packages/xhtml2pdf/util.py", line 123, in __call__
    return self.func(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/xhtml2pdf/util.py", line 205, in getColor
    value = str(value).strip().lower()
  File "/usr/local/lib/python3.9/site-packages/xhtml2pdf/w3c/css.py", line 656, in __repr__
    return '<CSS function: %s(%s)>' % (self.name, ', '.join(self.params))
TypeError: sequence item 1: expected str instance, tuple found
```

For invalid values like colors and background colors makes more sense to assign a default value rather than throwing an error, similar to browser. #352 