### PR TITLE
Fix background-image

### DIFF
--- a/xhtml2pdf/builders/watermarks.py
+++ b/xhtml2pdf/builders/watermarks.py
@@ -120,7 +120,8 @@ class WaterMarks:
                 pagebg = bginput.getPage(0)
                 page = input1.getPage(ctr-1)
                 if index%step == 0:
-                    page.mergePage(pagebg)
+                    pagebg.mergePage(page)
+                    page = pagebg
                 pdfoutput.addPage(page)
                 has_bg=True
         if has_bg:

--- a/xhtml2pdf/builders/watermarks.py
+++ b/xhtml2pdf/builders/watermarks.py
@@ -114,9 +114,8 @@ class WaterMarks:
         input1 = PyPDF3.PdfFileReader(istream)
         has_bg=False
         for pages, bgouter, step in WaterMarks.get_watermark(context, input1.numPages):
-            bginput = PyPDF3.PdfFileReader(bgouter.getBytesIO())
-
             for index, ctr in enumerate(pages):
+                bginput = PyPDF3.PdfFileReader(bgouter.getBytesIO())
                 pagebg = bginput.getPage(0)
                 page = input1.getPage(ctr-1)
                 if index%step == 0:


### PR DESCRIPTION
This fixes issue #614. 

Using `mergePage`, the argument page will be rendered on top of the other page, so these need to be switched. `bginput` needs to be moved into the for loop to prevent each page from stacking on top of each other.