### PR TITLE
fix ListItem styling

### DIFF
--- a/xhtml2pdf/default.py
+++ b/xhtml2pdf/default.py
@@ -587,6 +587,10 @@ ol {
     margin-left: 1.5em;
 }
 
+ul li div {
+    display: inline-block;
+}
+
 pre {
     white-space: pre;
 }

--- a/xhtml2pdf/default.py
+++ b/xhtml2pdf/default.py
@@ -587,7 +587,7 @@ ol {
     margin-left: 1.5em;
 }
 
-ul li div {
+ul li div:first-child {
     display: inline-block;
 }
 


### PR DESCRIPTION
ListsItems (`li`) which contain `div`s do lno longer miss the list indicator icon.

**Fixes:** #611
**Partially fixes:** #145