### PR TITLE
fix inline icons not being rendered correctly

### DIFF
--- a/xhtml2pdf/default.py
+++ b/xhtml2pdf/default.py
@@ -400,7 +400,6 @@ html {
     font-size: 10px;
     font-weight: normal;
     color: #000000;
-    background-color: transparent;
     margin: 0;
     padding: 0;
     line-height: 150%;


### PR DESCRIPTION
Setting **any** `background-color` on the `html` elment breaks inline icons. This includes values like `none`, `initial`, `inherit`, `unset`, all rgb(a) colors, as well as invalid values.

There's probably an underlying issue I wasn't able to find, but this PR at least fixes the visible symptom.

**Fixes:** #636