### PR TITLE
Replace PyPDF3 by pypdf

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ As with all open-source software, its use in production depends on many factors,
 About
 =====
 
-xhtml2pdf is a HTML to PDF converter using Python, the ReportLab Toolkit, html5lib and PyPDF3. It supports HTML5 and CSS 2.1 (and some of CSS 3). It is completely written in pure Python, so it is platform independent.
+xhtml2pdf is a HTML to PDF converter using Python, the ReportLab Toolkit, html5lib and pypdf. It supports HTML5 and CSS 2.1 (and some of CSS 3). It is completely written in pure Python, so it is platform independent.
 
 The main benefit of this tool is that a user with web skills like HTML and CSS is able to generate PDF templates very quickly without learning new technologies.
 

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     maintainer_email="luisza14@gmail.com",
     url="http://github.com/xhtml2pdf/xhtml2pdf",
     keywords="PDF, HTML, XHTML, XML, CSS",
-    install_requires=["html5lib>=1.0.1", "PyPDF3>=1.0.5", "Pillow>=8.1.1",
+    install_requires=["html5lib>=1.0.1", "pypdf>=3.0.0", "Pillow>=8.1.1",
                       "reportlab>=3.5.53", "svglib>=1.2.1",
                       "python-bidi>=0.4.2", "arabic-reshaper>=2.1.0",
                       "pyHanko>=0.12.1",

--- a/tests/test_asian_font_support.py
+++ b/tests/test_asian_font_support.py
@@ -2,7 +2,7 @@
 import io
 from unittest import TestCase
 
-from PyPDF3 import PdfFileReader
+from pypdf import PdfReader
 from reportlab.pdfbase import _cidfontdata
 
 from xhtml2pdf.document import pisaDocument
@@ -113,7 +113,7 @@ class AsianFontSupportTests(TestCase):
                 src=self.HTML_CONTENT,
                 dest=pdf_file)
             pdf_file.seek(0)
-            pdf_content = PdfFileReader(pdf_file)
+            pdf_content = PdfReader(pdf_file)
             pdf_fonts = read_fonts_from_pdf(pdf_content)
 
         # Read the fonts from the html content
@@ -161,7 +161,7 @@ def read_fonts_from_pdf(pdf):
     fonts = set()
 
     for page in pdf.pages:
-        obj = page.getObject()
+        obj = page.get_object()
         fonts = get_fonts_from_page(obj['/Resources']['/Font'], fonts)
 
     return fonts

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -5,7 +5,7 @@ import os
 import tempfile
 from unittest import TestCase, skipIf
 
-from PyPDF3 import PdfFileReader
+from pypdf import PdfReader
 
 from xhtml2pdf.document import pisaDocument
 
@@ -71,8 +71,8 @@ class DocumentTest(TestCase):
         # Rewind to the start of the file to read the pdf and get the
         # document's metadata
         pdf_file.seek(0)
-        pdf_reader = PdfFileReader(pdf_file)
-        pdf_info = pdf_reader.documentInfo
+        pdf_reader = PdfReader(pdf_file)
+        pdf_info = pdf_reader.metadata
 
         # Check the received metadata matches the expected metadata
         for original_key in METADATA:
@@ -96,9 +96,9 @@ class DocumentTest(TestCase):
                 dest=pdf_file
             )
             pdf_file.seek(0)
-            pdf_reader = PdfFileReader(pdf_file)
+            pdf_reader = PdfReader(pdf_file)
 
-            xobjects = pdf_reader.getPage(0)['/Resources']['/XObject'].getObject()
+            xobjects = pdf_reader.pages[0]['/Resources']['/XObject'].get_object()
             objects = [xobjects[key] for key in xobjects.keys()]
 
             # Identity the 'denker_transparent.png' image by its height and width, and make sure it's there.
@@ -122,9 +122,9 @@ class DocumentTest(TestCase):
                 dest=pdf_file
             )
             pdf_file.seek(0)
-            pdf_reader = PdfFileReader(pdf_file)
+            pdf_reader = PdfReader(pdf_file)
 
-            xobjects = pdf_reader.getPage(0)['/Resources']['/XObject'].getObject()
+            xobjects = pdf_reader.pages[0]['/Resources']['/XObject'].get_object()
             objects = [xobjects[key] for key in xobjects.keys()]
 
             # Identity the 'denker_transparent.png' image by its height and width, and make sure it's there.
@@ -150,9 +150,9 @@ class DocumentTest(TestCase):
                 dest=pdf_file
             )
             pdf_file.seek(0)
-            pdf_reader = PdfFileReader(pdf_file)
+            pdf_reader = PdfReader(pdf_file)
 
-            self.assertEqual(pdf_reader.getNumPages(), 2)
+            self.assertEqual(len(pdf_reader.pages), 2)
 
     def test_document_nested_table(self):
         """
@@ -170,8 +170,8 @@ class DocumentTest(TestCase):
                 dest=pdf_file
             )
             pdf_file.seek(0)
-            pdf_reader = PdfFileReader(pdf_file)
-            self.assertEqual(pdf_reader.getNumPages(), 1)
+            pdf_reader = PdfReader(pdf_file)
+            self.assertEqual(len(pdf_reader.pages), 1)
 
 
     @skipIf(IN_PYPY, "This doesn't work in pypy")

--- a/xhtml2pdf/builders/signs.py
+++ b/xhtml2pdf/builders/signs.py
@@ -188,7 +188,7 @@ class PDFSignature:
     def simple_sign(inputfile, output, config):
         signer = PDFSignature.get_signers(config)
         if signer:
-            w = IncrementalPdfFileWriter(inputfile)
+            w = IncrementalPdfWriter(inputfile)
             timestamper = PDFSignature.get_timestamps(config)
             signers.sign_pdf(
                 w, signers.PdfSignatureMetadata(field_name='Signature1'),
@@ -200,7 +200,7 @@ class PDFSignature:
     def lta_sign(inputfile, output, config):
         signer = PDFSignature.get_signers(config)
         timestamper = PDFSignature.get_timestamps(config)
-        w = IncrementalPdfFileWriter(inputfile)
+        w = IncrementalPdfWriter(inputfile)
         meta=PDFSignature.get_signature_meta(config)
 
         signature_meta = signers.PdfSignatureMetadata(**meta)

--- a/xhtml2pdf/builders/watermarks.py
+++ b/xhtml2pdf/builders/watermarks.py
@@ -1,4 +1,4 @@
-import PyPDF3
+import pypdf
 from PIL import Image
 from reportlab.pdfgen.canvas import Canvas
 
@@ -57,7 +57,7 @@ class WaterMarks:
     @staticmethod
     def generate_pdf_background(pisafile, pagesize, is_portrait, context={}):
         """
-        PyPDF3 requires pdf as background so convert image to pdf in temporary file with same page dimensions
+        pypdf requires pdf as background so convert image to pdf in temporary file with same page dimensions
         :param pisafile:  Image File
         :param pagesize:  Page size for the new pdf
         :return: pisaFileObject as tempfile
@@ -110,18 +110,18 @@ class WaterMarks:
 
     @staticmethod
     def process_doc(context, istream, output):
-        pdfoutput = PyPDF3.PdfFileWriter()
-        input1 = PyPDF3.PdfFileReader(istream)
+        pdfoutput = pypdf.PdfWriter()
+        input1 = pypdf.PdfReader(istream)
         has_bg=False
-        for pages, bgouter, step in WaterMarks.get_watermark(context, input1.numPages):
+        for pages, bgouter, step in WaterMarks.get_watermark(context, len(input1.pages)):
             for index, ctr in enumerate(pages):
-                bginput = PyPDF3.PdfFileReader(bgouter.getBytesIO())
-                pagebg = bginput.getPage(0)
-                page = input1.getPage(ctr-1)
+                bginput = pypdf.PdfReader(bgouter.getBytesIO())
+                pagebg = bginput.pages[0]
+                page = input1.pages[ctr-1]
                 if index%step == 0:
-                    pagebg.mergePage(page)
+                    pagebg.merge_page(page)
                     page = pagebg
-                pdfoutput.addPage(page)
+                pdfoutput.add_page(page)
                 has_bg=True
         if has_bg:
             pdfoutput.write(output)

--- a/xhtml2pdf/document.py
+++ b/xhtml2pdf/document.py
@@ -26,7 +26,7 @@ from xhtml2pdf.builders.watermarks import WaterMarks
 from xhtml2pdf.context import pisaContext
 from xhtml2pdf.default import DEFAULT_CSS
 from xhtml2pdf.parser import pisaParser
-from xhtml2pdf.util import PyPDF3, getBox
+from xhtml2pdf.util import pypdf, getBox
 from xhtml2pdf.files import pisaTempFile, cleanFiles
 from xhtml2pdf.xhtml2pdf_reportlab import PmlBaseDoc, PmlPageTemplate
 

--- a/xhtml2pdf/pdf.py
+++ b/xhtml2pdf/pdf.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 import logging
-from xhtml2pdf.util import PyPDF3
+from xhtml2pdf.util import pypdf
 from xhtml2pdf.files import getFile, pisaTempFile
 
 log = logging.getLogger("xhtml2pdf")
@@ -50,11 +50,11 @@ class pisaPDF:
             self.files.append(doc.dest)
 
     def join(self, file=None):
-        output = PyPDF3.PdfFileWriter()
+        output = pypdf.PdfWriter()
         for pdffile in self.files:
-            pdf = PyPDF3.PdfFileReader(pdffile)
-            for pageNumber in range(pdf.getNumPages()):
-                output.addPage(pdf.getPage(pageNumber))
+            pdf = pypdf.PdfReader(pdffile)
+            for pageNumber in range(len(pdf.pages)):
+                output.add_page(pdf.pages[pageNumber])
 
         if file is not None:
             output.write(file)

--- a/xhtml2pdf/util.py
+++ b/xhtml2pdf/util.py
@@ -36,7 +36,7 @@ rgb_re = re.compile(
 
 log = logging.getLogger("xhtml2pdf")
 
-import PyPDF3
+import pypdf
 from reportlab.graphics import renderPM
 from reportlab.graphics import renderSVG
 


### PR DESCRIPTION
PyPDF2 has recently moved to `pypdf`. Im the maintainer of PyPDF2 and pypdf.

PyPDF3 has a way smaller community than PyPDF2. I try to get the community to move to pypdf: https://github.com/sfneal/PyPDF3/issues/18

Swiftly going over some issues of xhtml2pdf:

* #624 : https://pypdf.readthedocs.io/en/latest/modules/PdfWriter.html#pypdf.PdfWriter.pdf_header
* #454 : We added modern encryption / decryption support - https://pypdf.readthedocs.io/en/latest/user/encryption-decryption.html