### PR TITLE
Update `arabic-reshaper` to remove `future`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-arabic-reshaper>=2.1.0
+arabic-reshaper>=3.0.0
 coverage>=5.3
 html5lib>=1.1
 Pillow>=8.1.1

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     keywords="PDF, HTML, XHTML, XML, CSS",
     install_requires=["html5lib>=1.0.1", "PyPDF3>=1.0.5", "Pillow>=8.1.1",
                       "reportlab>=3.5.53", "svglib>=1.2.1",
-                      "python-bidi>=0.4.2", "arabic-reshaper>=2.1.0",
+                      "python-bidi>=0.4.2", "arabic-reshaper>=3.0.0",
                       "pyHanko>=0.12.1",
                       "pyhanko-certvalidator>=0.19.5"],
     include_package_data=True,

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ commands =
     coverage run -m unittest discover tests
     coverage run -a testrender/testrender.py  --nofail --only-errors
 deps =
-    arabic-reshaper>=2.1.0
+    arabic-reshaper>=3.0.0
     coverage>=5.3
     html5lib>=1.1
     Pillow>=8.1.1


### PR DESCRIPTION
Upgrade to 3.0.0 to remove the vulnerable 'future' dependency

Fixes: #657