### PR TITLE
Fixed addFromURI in pisaPDF class

### DIFF
--- a/xhtml2pdf/pdf.py
+++ b/xhtml2pdf/pdf.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import logging
+from io import BytesIO
 from xhtml2pdf.util import PyPDF3
 from xhtml2pdf.files import getFile, pisaTempFile
 
@@ -30,7 +31,7 @@ class pisaPDF:
         obj = getFile(url, basepath)
         data = obj.getFileContent()
         if data:
-            self.files.append(data)
+            self.files.append(BytesIO(data))
 
     addFromFileName = addFromURI
 


### PR DESCRIPTION
The original code can fail for example on the line 55 where PyPDF3.PdfFileReader expects a stream. 

```
    def addFromURI(self, url, basepath=None):
        obj = getFile(url, basepath) 
        data = obj.getFileContent()  # the method returns bytes not BytesIO
        if data:
            self.files.append(data)

```