### PR TITLE
Fix changelog location in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -158,7 +158,7 @@ These are the major milestones and the maintainers of the project:
 * 2016-2018 Sam Spencer (@LegoStormtroopr)
 * 2018-Current Luis Zarate (@luisza) 
 
-For more history, see the ``CHANGELOG.txt`` file.
+For more history, see the `Release Notes <https://xhtml2pdf.readthedocs.io/en/latest/release-notes.html>`__.
 
 License
 =======


### PR DESCRIPTION
Hi, I fixed #650 by replacing the old reference to the `CHANGELOG.txt` file with the latest release notes. The `CHANGELOG.txt` file was renamed to `docs/source/release-notes.rst` but this reference had not been updated.