### PR TITLE
add missing import

### DIFF
--- a/xhtml2pdf/parser.py
+++ b/xhtml2pdf/parser.py
@@ -72,6 +72,7 @@ from xhtml2pdf.tags import (pisaTagIMG,
                             pisaTagUL,
                             pisaTagINPUT,
                             pisaTagTEXTAREA,
+                            pisaTagCANVAS,
                             # pisaTagSELECT,
                             # pisaTagOPTION
                             )


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
The pisaTagCANVAS import has been removed from the parser.py file, and following this canvases began showing as just a JSON object.  Returned the import.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Added missing canvas import to the parser.py file


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #676
