### PR TITLE
Fix duplicate page number/number of pages

### DIFF
--- a/xhtml2pdf/context.py
+++ b/xhtml2pdf/context.py
@@ -669,7 +669,8 @@ class pisaContext(object):
                 # We need this empty fragment to work around problems in
                 # Reportlab paragraphs regarding backGround etc.
                 if self.fragList:
-                    self.fragList.append(self.fragList[- 1].clone(text=''))
+                    # Reset not only text but also page#, otherwise you might end up with duplicate rendered page#s
+                    self.fragList.append(self.fragList[-1].clone(text='', pageNumber=False, pageCount=False))
                 else:
                     blank = self.frag.clone()
                     blank.fontName = "Helvetica"


### PR DESCRIPTION
### Short description
This PR should resolve the issue with page numbers and page count being rendered twice, if they occur at the very end of a paragraph (or similar block).

### Proposed changes
For some reason, the last frag of a paragraph is being duplicated before the paragraph is added to the story. While its text was being reset to empty, the page number/count flags were not, thus leading to the duplication. The PR resets both flags as well.

### Resolved issues

Fixes: #106 (nearly in time for its tenth anniversary!)
