### PR TITLE
changed print statement to log.exception

### DIFF
--- a/xhtml2pdf/context.py
+++ b/xhtml2pdf/context.py
@@ -383,7 +383,7 @@ class pisaCSSParser(css.CSSParser):
             result = self.parse(cssFile.getData())
             self.rootPath = oldRootPath
         except Exception as e:
-            log.error(e)
+            log.exception(e)
         return result
 
 

--- a/xhtml2pdf/context.py
+++ b/xhtml2pdf/context.py
@@ -383,7 +383,7 @@ class pisaCSSParser(css.CSSParser):
             result = self.parse(cssFile.getData())
             self.rootPath = oldRootPath
         except Exception as e:
-            print(e)
+            log.error(e)
         return result
 
 


### PR DESCRIPTION
### Short description
When converting specific HTML documents I keep seeing this line `expected string or bytes-like object, got 'NoneType'` printed (not logged, print) again and again. I traced it down to a single line that was written 6 years ago in the CSSParser. I switched that line to use `log.error`. It is much preferred to use logging instead of print and i need to handle these in our JSON logger. Alternative choices are `log.exception` to see the trace, `log.warning` to let users know that this error isn't a real failure case, or one of the built in logging functionalities. I am new to this project so I don't know what is preferred.


### Proposed changes
change:
```
except Exception as e:
    print(e)
```
to:
```
except Exception as e:
    log.error(e)
```


### Testing
- ran `nosetests --with-coverage`
```
Name                                      Stmts   Miss Branch BrPart   Cover
----------------------------------------------------------------------------
xhtml2pdf/__init__.py                         1      0      0      0 100.00%
xhtml2pdf/builders/__init__.py                0      0      0      0 100.00%
xhtml2pdf/builders/signs.py                 155    111     66      0  19.91%
xhtml2pdf/builders/watermarks.py             82     12     28      8  81.82%
xhtml2pdf/charts.py                         175    126     56      0  21.21%
xhtml2pdf/config/__init__.py                  0      0      0      0 100.00%
xhtml2pdf/config/httpconfig.py               20     12      8      0  28.57%
xhtml2pdf/context.py                        578    169    206     50  65.94%
xhtml2pdf/default.py                         20      0      0      0 100.00%
xhtml2pdf/document.py                        83     25     42      9  61.60%
xhtml2pdf/files.py                          288     72     72     18  70.56%
xhtml2pdf/paragraph.py                      271     30     98     10  86.45%
xhtml2pdf/parser.py                         386     97    248     41  72.56%
xhtml2pdf/reportlab_paragraph.py           1128    589    522     71  43.88%
xhtml2pdf/tables.py                         182      5     70      3  96.83%
xhtml2pdf/tags.py                           447    233     90     17  43.76%
xhtml2pdf/util.py                           255     32    126      6  86.35%
xhtml2pdf/w3c/__init__.py                     0      0      0      0 100.00%
xhtml2pdf/w3c/css.py                        524    154    178     27  63.39%
xhtml2pdf/w3c/cssDOMElementInterface.py      60     19     26      3  62.79%
xhtml2pdf/w3c/cssParser.py                  661    223    266     48  60.84%
xhtml2pdf/w3c/cssSpecial.py                 197      9    100     11  92.59%
xhtml2pdf/xhtml2pdf_reportlab.py            595    262    220     40  51.66%
----------------------------------------------------------------------------
TOTAL                                      6108   2180   2422    362  60.14%
----------------------------------------------------------------------
Ran 167 tests in 18.024s

OK
```
