### PR TITLE
Fix documentation of page templates.

### DIFF
--- a/docs/source/format_html.rst
+++ b/docs/source/format_html.rst
@@ -308,7 +308,7 @@ large 5cm margins and regular pages with regular 2cm margins.
     <html>
     <head>
     <style>
-        @page title_template { margin: 5cm; }
+        @page { margin: 5cm; }
         @page regular_template { margin: 2cm; }
     </style>
     </head>


### PR DESCRIPTION
### Short description
When I use multiple page templates it only works for me, when the first template is not named. The first page doesn't has any template when I name the first page temple like the documentation says.


### Proposed changes
- I updated the documentation and removed the name in the example code


### Resolved issues
-

Fixes: #
