### PR TITLE
Modernize Sphinx configuration

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -44,8 +44,10 @@ extensions = [
 
 
 # Shortening external links. Here: issue & PR tracker of GitHub
-extlinks = {'issue': ('https://github.com/xhtml2pdf/xhtml2pdf/issues/%s', '#'),
-            'pr': ('https://github.com/xhtml2pdf/xhtml2pdf/pull/%s', '#')}
+extlinks = {
+    'issue': ('https://github.com/xhtml2pdf/xhtml2pdf/issues/%s', '#%s'),
+    'pr': ('https://github.com/xhtml2pdf/xhtml2pdf/pull/%s', '#%s')
+}
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -82,7 +84,7 @@ release = '0.2.7'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
@@ -442,6 +444,8 @@ epub_exclude_files = ['search.html']
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/': None}
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/', None),
+}
 import build_samples as bs
 bs.build_resources()

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -27,7 +27,7 @@ Versions >= 0.2
 
     **🐛 Bug-Fixes**
 
-    * Note: Please reference GitHub issues with :issue:´999´ and pull requests with :pr:´999´
+    * Note: Please reference GitHub issues with :issue:`999` and pull requests with :pr:`999`
     *
 
     **⚠️ Deprecation**
@@ -59,7 +59,7 @@ This release only aims to fix issues with pycairo and xhtml2pdf dependencies wit
 
 **🐛 Bug-Fixes**
 
-* Fix setup.py and requirements dependency to set reportlab>=3.5.53,<4 :issue:´688´ in :pr:´690´
+* Fix setup.py and requirements dependency to set reportlab>=3.5.53,<4 :issue:`688` in :pr:`690`
 
 | Thanks to the following people on GitHub for contributing to this release:
 | *gaurab-10*, *jorenham* 
@@ -73,11 +73,11 @@ Released: 2023-04-20
 
 **🐛 Bug-Fixes**
 
-* Fix canvas graph issue :issue:´614´ in :pr:´619´
+* Fix canvas graph issue :issue:`614` in :pr:`619`
 
 **🧹 Cleanup**
 
-* Remove duplicate pypdf entry from `setup.py` in :pr:´619´
+* Remove duplicate pypdf entry from `setup.py` in :pr:`619`
 
 | Thanks to the following people on GitHub for contributing to this release:
 | *brandonlake-semaphore*, *sunpoet*
@@ -119,9 +119,9 @@ Released: 2022-06-16
 
 **🐛 Bug-Fixes**
 
-* Fix background-image issues with :issue:´614´ and pull requests with :pr:´619´
-* Fix CSSParseError for minified @font-face definitions  :pr:´609´ 
-* Fixed a few typos and grammar mistakes in usage.rst documentation. :pr:´610´
+* Fix background-image issues with :issue:`614` and pull requests with :pr:`619`
+* Fix CSSParseError for minified @font-face definitions  :pr:`609`
+* Fixed a few typos and grammar mistakes in usage.rst documentation. :pr:`610`
 
 
 | Thanks to the following people on GitHub for contributing to this release:
@@ -161,6 +161,7 @@ Released: 2022-03-31
 
 | Thanks to the following people on GitHub for contributing to this release:
 | *marcelagz* for graphics support :)
+
 --------------------------------------------
 
 
@@ -188,7 +189,7 @@ Released: 2022-03-11
 
 **🐛 Bug-Fixes**
 
-* Fix UnboundLocalError in reportlab_paragraph (#585) (#586)
+* Fix UnboundLocalError in reportlab_paragraph (:issue:`585`) (:pr:`586`)
 
 **📘 Documentation**
 
@@ -419,15 +420,15 @@ Released: 2016-05-18
 
 * Removed PyPy support
 * Avoid exceptions likely to occur systematic to how narrow a text column is #309 - thanks *jkDesignDE*
-* Improved tests for tables #305 - thanks *taddeimania*
-* Fix broken empty PDFs in Python2 #301 - thanks *citizen-stig*
-* Unknown page sizes now raise an exception #71 - thanks *benjaoming*
-* Unorderable types caused by duplicate CSS selectors / rules #69 - thanks *benjaoming*
-* Allow empty page definition with no space after @page - #88 - thanks *benjaoming*
-* Error when in addFromFile using file-like object #245 - thanks *benjaoming*
-* Python 3: Bad table formatting with empty columns #279 - thanks *citizen-stig and benjaoming*
-* Removed paragraph2.py, unused ghost file since the beginning of the project #289 - thanks *citizen-stig*
-* Catch-all exceptions removed in a lot of places, not quite done #290 - thanks *benjaoming*
+* Improved tests for tables :pr:`305` - thanks *taddeimania*
+* Fix broken empty PDFs in Python2 :pr:`301` - thanks *citizen-stig*
+* Unknown page sizes now raise an exception :pr:`71` - thanks *benjaoming*
+* Unorderable types caused by duplicate CSS selectors / rules :pr:`69` - thanks *benjaoming*
+* Allow empty page definition with no space after @page - :pr:`88` - thanks *benjaoming*
+* Error when in addFromFile using file-like object :pr:`245` - thanks *benjaoming*
+* Python 3: Bad table formatting with empty columns :pr:`279` - thanks *citizen-stig and benjaoming*
+* Removed paragraph2.py, unused ghost file since the beginning of the project :pr:`289` - thanks *citizen-stig*
+* Catch-all exceptions removed in a lot of places, not quite done :pr:`290` - thanks *benjaoming*
 
 
 --------------------------------------------
@@ -437,10 +438,10 @@ Released: 2016-05-18
 
 Released: 2016-05-01
 
-* Improved six usage, simplifies codebase #288 - thanks *citizen-stig*
-* Removed mutable types as default args #287 - thanks *citizen-stig*
-* Fix "hangs forever on simple input" #209
-* Base64 inline <img> works now #281 
+* Improved six usage, simplifies codebase :pr:`288` - thanks *citizen-stig*
+* Removed mutable types as default args :pr:`287` - thanks *citizen-stig*
+* Fix "hangs forever on simple input" :pr:`209`
+* Base64 inline <img> works now :pr:`281`
 
 --------------------------------------------
 
@@ -449,8 +450,8 @@ Released: 2016-05-01
 
 Released: 2016-04-14
 
-* Fixed: AttributeError: 'bytes' object has no attribute 'encode' #265
-* Improved tests, added code coverage 
+* Fixed: AttributeError: 'bytes' object has no attribute 'encode' :pr:`265`
+* Improved tests, added code coverage
 
 --------------------------------------------
 
@@ -479,7 +480,7 @@ Versions < 0.1
 Released: 2014-04-27
 
 * get css backgrounds and fonts relative to the css file path
-* fix CSS parser breaking on "@media screen and ..." (issue 132)
+* fix CSS parser breaking on "@media screen and ..." (:issue:`132`)
 
 --------------------------------------------
 
@@ -565,7 +566,7 @@ Version 3.0.32, 2009-05-08
 
 - NEW: New command line option '--base' to specify base path if input comes via STDIN
 - FIX: The 'keep in frame' feature for tables did not work inside of static frames (Arun Shanker Prasad)
-- FIX: Small typos 
+- FIX: Small typos
 
 Version 3.0.31, 2009-05-04
 
@@ -587,7 +588,7 @@ Version 3.0.30, 2009-03-27
 - FIX: Small bug fix for show_error_as_pdf
 - FIX: Demos used os.startfile which is not supported on non Windows OSes
 - FIX: Table available height threw exceptions
-- FIX: Switched from urllib2 to httplib for loading external sources 
+- FIX: Switched from urllib2 to httplib for loading external sources
 - FIX: Correct homepage and download page in setup.py
 - FIX: Paragraphs in lists repeated the bullet
 - FIX: Tables now support -pdf-keep-with-next


### PR DESCRIPTION
### Short description

This PR resolves the build warnings when building the docs with the latest Sphinx versions. Additionally, some missing issue/PR links have been added.


### Proposed changes

- Set language code to English due to:

  > WARNING: Invalid configuration value found: 'language = None'. Update your configuration to a valid language code. Falling back to 'en' (English).

- Switch to the new `intersphinx_mapping` format due to:

  > WARNING: The pre-Sphinx 1.0 'intersphinx_mapping' format is deprecated and will be removed in Sphinx 8. Update to the current format as described in the documentation. Hint: "intersphinx_mapping = {'<name>': ('https://docs.python.org/', None)}".https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html#confval-intersphinx_mapping

- Add a newline to resolve

  > /home/docs/checkouts/readthedocs.org/user_builds/xhtml2pdf/checkouts/latest/docs/source/release-notes.rst:163: WARNING: Line block ends without a blank line.

- Use the issue/PR number for the issue and PR directive labels to fix

  ```
  Exception occurred:
    File "/home/docs/checkouts/readthedocs.org/user_builds/xhtml2pdf/envs/latest/lib/python3.9/site-packages/sphinx/ext/extlinks.py", line 108, in role
      title = caption % part
  TypeError: not all arguments converted during string formatting
  ```

  This is documented in the official docs at https://www.sphinx-doc.org/en/master/usage/extensions/extlinks.html: The caption (the second tuple element) needs to always be either `None` to use the full URL or a string which contains the placeholder `%s` exactly once.

  Additionally, the directives have been fixed to use the format from the official docs inside the actual RST.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #710 
