### PR TITLE
Add license notes for the `w3c` module

### DIFF
--- a/xhtml2pdf/w3c/LICENSE.md
+++ b/xhtml2pdf/w3c/LICENSE.md
@@ -1,0 +1,76 @@
+## License notices for `xhtml2pdf.w3c`
+
+The CSS parser functionality available in this submodule has originally been developed by TechGame Networks, LLC as part of their TG Framework module.
+A copy of this code has been incorporated into xhtml2pdf to apply custom patches with the first commit in 2010, while adding a new original file `cssSpecial.py`.
+
+The TG Framework changed its license from BSD-3-Clause to MIT according to the available Git history in March 2008.
+As the corresponding file headers and the files inside the `w3c` directory have not been altered after 2007-04-04, the incorporated code can be used under both of these licenses.
+
+Both BSD-3-Clause and MIT are rather permissive licenses and thus it should not pose a problem for xhtml2pdf.
+All changes made to these files are subject to the general xhtml2pdf license, id est Apache-2.0 (see the `LICENSE.txt` file in the repository root for details).
+
+### References
+
+* [Issue with research results](https://github.com/xhtml2pdf/xhtml2pdf/issues/696)
+* [Current Git code of the TG Framework `w3c` module](https://github.com/techgame/tg-framework/tree/master/w3c)
+* [Git history of the TG Framework `w3c` module](https://github.com/techgame/tg-framework/commits/master/w3c)
+* [Git history of the TG Framework `proj/w3c` directory](https://github.com/techgame/tg-framework/commits/cfad4675d3a6c1aafaf55929a2ef57a169dad4d8/proj/w3c) (old directory of the `w3c` module)
+* [License history of TG Framework](https://github.com/techgame/tg-framework/commits/master/LICENSE.txt)
+* [Initial commit for xhtml2pdf](https://github.com/xhtml2pdf/xhtml2pdf/commit/881850e49b67d8c9111ac53d09fb90138c1a3320)
+
+### Original license texts
+
+This is the initial license text for TG Framework (until 2008-03-19):
+
+```
+Copyright (c) 2002-2004, TechGame Networks, LLC.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted 
+provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice, 
+      this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above copyright notice, 
+      this list of conditions and the following disclaimer in the documentation and/or 
+      other materials provided with the distribution.
+
+    * Neither the name of TechGame Networks, LLC nor the names of its contributors may 
+      be used to endorse or promote products derived from this software without specific 
+      prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS 
+OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY 
+AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER 
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT 
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+```
+
+This is the license text of TG Framework after the change on 2008-03-19:
+
+```
+Copyright (c) 2002-2008, TechGame Networks, LLC.
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+```


### PR DESCRIPTION
### Short description

This adds license notes for the `xhtml2pdf.w3c` module.

### Proposed changes

Licensing for the `xhtml2pdf.w3c` module has not been clear in the past, as it only referenced a "BSD like License". A corresponding file has been added explaining the license history and status after doing some research.

I refrained from updating the file headers for now, as removing existing external copyright headers usually is discouraged/wrong. If desired, I can still update them to add an additional section with the usual Apache-2.0 header.

Please note that this is a rather sensitive change due to dealing with licensing stuff and using appropriate wording therefore is hard. As always in these cases: IANAL.

### Resolved issues

Fixes: #696 
