### PR TITLE
Drop support for Python 3.7

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     env:
       PYTHON_VERSION: ${{matrix.python-version}}
     steps:

--- a/README.rst
+++ b/README.rst
@@ -54,7 +54,7 @@ This is a typical Python library and can be installed using pip::
 Requirements
 ============
 
-Only Python 3.7+ is tested and guaranteed to work.
+Only Python 3.8+ is tested and guaranteed to work.
 
 All additional requirements are listed in the ``pyproject.toml`` file and are installed automatically using the ``pip install .`` method.
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -11,7 +11,7 @@ This is a typical Python library and is installed using pip
 Requirements
 ------------
 
-Python 3.7+
+Python 3.8+
 
 All additional requirements are listed in ``pyproject.toml`` file and are
 installed automatically using the ``pip install xhtml2pdf`` method.

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -72,6 +72,7 @@ Unreleased
 * Enforce consistent file formatting (:pr:`715`)
 * Add ruff code linter (:pr:`716`)
 * Start using type hints & validate them via mypy (:pr:`717`)
+* Drop support for Python 3.7 (reached end of life on 2023-06-27) (:pr:`718`)
 
 | Thanks to the following people on GitHub for contributing to this release:
 | *JanEgner*, *lucasgadams*, *a-detiste*, *holtwick*, *stefan6419846*, *timobrembeck*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ classifiers = [
     "Natural Language :: English",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -45,7 +44,7 @@ classifiers = [
     "Topic :: Text Processing :: Markup :: XML",
     "Topic :: Utilities",
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dependencies = [
     "arabic-reshaper>=3.0.0",
     "html5lib>=1.1",
@@ -92,7 +91,7 @@ exclude = ["tests", "tests.*", "manual_test", "manual_test.*"]
 [tool.tox]
 legacy_tox_ini = """
     [tox]
-    envlist = py{3.7,3.8,3.9,3.10,3.11}
+    envlist = py{3.8,3.9,3.10,3.11}
 
     [testenv]
     deps = coverage[toml]


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Drop support for Python 3.7, which reached its end of life on 2023-06-27: https://devguide.python.org/versions/