### PR TITLE
Add support for Python 3.12

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -7,7 +7,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v4
       with:
-        python-version: "3.11"
+        python-version: "3.12"
     - uses: pre-commit/action@v3.0.0
       env:
         SKIP: black,ruff,mypy,no-commit-to-branch
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.12"
       - uses: psf/black@stable
         with:
           version: "23.9.1"
@@ -34,6 +34,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: jpetrucciani/mypy-check@1.5.1
         with:
-          python_version: "3.11"
+          python_version: "3.12"
           mypy_flags: '--config-file pyproject.toml --ignore-missing-imports --scripts-are-modules'
           requirements: "types-pkg_resources"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     env:
       PYTHON_VERSION: ${{matrix.python-version}}
     steps:

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -73,6 +73,7 @@ Unreleased
 * Add ruff code linter (:pr:`716`)
 * Start using type hints & validate them via mypy (:pr:`717`)
 * Drop support for Python 3.7 (reached end of life on 2023-06-27) (:pr:`718`)
+* Add support for Python 3.12 (released on 2023-10-02) (:pr:`719`)
 
 | Thanks to the following people on GitHub for contributing to this release:
 | *JanEgner*, *lucasgadams*, *a-detiste*, *holtwick*, *stefan6419846*, *timobrembeck*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Documentation",
     "Topic :: Multimedia",
     "Topic :: Office/Business",
@@ -91,7 +92,7 @@ exclude = ["tests", "tests.*", "manual_test", "manual_test.*"]
 [tool.tox]
 legacy_tox_ini = """
     [tox]
-    envlist = py{3.8,3.9,3.10,3.11}
+    envlist = py{3.8,3.9,3.10,3.11,3.12}
 
     [testenv]
     deps = coverage[toml]


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Add support for Python 3.12, which was released on 2023-10-02: https://devguide.python.org/versions/