### PR TITLE
Fix readthedocs build

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,7 +15,8 @@ documentation root, use os.path.abspath to make it absolute, like shown here.
 from __future__ import annotations
 
 from xhtml2pdf import __version__
-from xhtml2pdf.build_samples import build_resources
+
+from .build_samples import build_resources
 
 build_resources()
 


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
I hope this fixes the following error:

```
ModuleNotFoundError: No module named 'xhtml2pdf.build_samples'
```
– https://readthedocs.org/projects/xhtml2pdf/builds/22153025/