### PR TITLE
Fix `ZeroDivisionError` on broken image files

### DIFF
--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -56,6 +56,7 @@ Unreleased
 **🐛 Bug-Fixes**
 
 * Fix page number & page count (:issue:`106`) (:pr:`695`)
+* Fix ``ZeroDivisionError`` on broken image files (:pr:`723`)
 
 **📘 Documentation**
 

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -154,6 +154,27 @@ class DocumentTest(TestCase):
 
             self.assertEqual(len(pdf_reader.pages), 2)
 
+    def test_document_with_broken_image(self) -> None:
+        """Test that broken images don't cause unhandled exception"""
+        # Although this is just html, it will be recognized as svg
+        image_path = "https://raw.githubusercontent.com/xhtml2pdf/xhtml2pdf/b01b1d8f9497dedd0f2454409d03408bdeea997c/tests/samples/images.html"
+        extra_html = f'<img src="{image_path}">'
+        with open(os.devnull, "wb") as pdf_file, self.assertLogs(
+            "xhtml2pdf.xhtml2pdf_reportlab", level="WARNING"
+        ) as cm:
+            pisaDocument(
+                src=io.StringIO(HTML_CONTENT.format(head="", extra_html=extra_html)),
+                dest=pdf_file,
+            )
+            self.assertEqual(
+                cm.output,
+                [
+                    "WARNING:xhtml2pdf.xhtml2pdf_reportlab:SVG drawing could not be"
+                    " resized:"
+                    " 'https://raw.githubusercontent.com/xhtml2pdf/xhtml2pdf/b01b1d8f9497dedd0f2454409d03408bdeea997c/tests/samples/images.html'"
+                ],
+            )
+
     def test_document_nested_table(self) -> None:
         """Test that nested tables are being rendered."""
         tests_folder = os.path.dirname(os.path.realpath(__file__))

--- a/xhtml2pdf/context.py
+++ b/xhtml2pdf/context.py
@@ -18,6 +18,7 @@ import logging
 import re
 import urllib.parse as urlparse
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from reportlab import rl_settings
 from reportlab.lib.enums import TA_LEFT
@@ -53,6 +54,10 @@ from xhtml2pdf.xhtml2pdf_reportlab import (
     PmlParagraphAndImage,
     PmlTableOfContents,
 )
+
+if TYPE_CHECKING:
+    from xhtml2pdf.xhtml2pdf_reportlab import PmlImage
+
 
 rl_settings.warnOnMissingFontGlyphs = 0
 log = logging.getLogger(__name__)
@@ -573,19 +578,22 @@ class pisaContext:
         self.log: list = []
         self.path: list = []
         self.pisaBackgroundList: list = []
+        self.select_options: list[str] = []
         self.story: list = []
-        self.image = None
+        self.image: PmlImage | None = None
         self.indexing_story = None
         self.keepInFrameIndex = None
         self.node = None
         self.template = None
         self.tableData: TableData = TableData()
         self.err: int = 0
+        self.fontSize: int = 0
         self.listCounter: int = 0
         self.uidctr: int = 0
         self.warn: int = 0
         self.cssDefaultText: str = ""
         self.cssText: str = ""
+        self.language: str = ""
         self.text: str = ""
         self.frameStatic: dict = {}
         self.imageData: dict = {}

--- a/xhtml2pdf/parser.py
+++ b/xhtml2pdf/parser.py
@@ -124,7 +124,9 @@ def pisaGetAttributes(c, tag, attributes):
                 # XXX no Unicode! Reportlab fails with template names
                 attrs[str(k)] = str(v)
             except Exception as e:  # noqa: PERF203
-                log.debug("%s during string conversion for %s=%s", e, k, v, exc_info=1)
+                log.debug(
+                    "%s during string conversion for %s=%s", e, k, v, exc_info=True
+                )
                 attrs[k] = v
 
     nattrs = {}
@@ -335,7 +337,7 @@ def CSSCollect(node, c):
             # except LookupError:
             #    pass
             except Exception as e:  # noqa: PERF203
-                log.debug("%r during CSS attr '%s'", e, cssAttrName, exc_info=1)
+                log.debug("%r during CSS attr '%s'", e, cssAttrName, exc_info=True)
 
         CSSAttrCache[key] = node.cssAttrs
     return node.cssAttrs

--- a/xhtml2pdf/tags.py
+++ b/xhtml2pdf/tags.py
@@ -312,7 +312,7 @@ class pisaTagLI(pisaTag):
             frag.text = ""
             f = frag.listStyleImage
             if f and (not f.notFound()):
-                img = PmlImage(f.getData(), width=None, height=None)
+                img = PmlImage(f.getData(), src=f.uri, width=None, height=None)
                 img.drawHeight *= DPI96
                 img.drawWidth *= DPI96
                 img.pisaZoom = frag.zoom
@@ -364,7 +364,7 @@ class pisaTagIMG(pisaTag):
                     if attr.height:
                         height = attr.height * DPI96
 
-                    img = PmlImage(filedata, width=None, height=None)
+                    img = PmlImage(filedata, src=attr.src.uri, width=None, height=None)
 
                     img.pisaZoom = c.frag.zoom
 

--- a/xhtml2pdf/tags.py
+++ b/xhtml2pdf/tags.py
@@ -19,7 +19,7 @@ import logging
 import re
 import string
 import warnings
-from typing import ClassVar
+from typing import TYPE_CHECKING, Callable, ClassVar
 
 from reportlab.graphics.barcode import createBarcodeDrawing
 from reportlab.graphics.charts.legends import Legend
@@ -44,27 +44,34 @@ from xhtml2pdf.paragraph import PageNumberFlowable
 from xhtml2pdf.util import DPI96, getAlign, getColor, getSize
 from xhtml2pdf.xhtml2pdf_reportlab import PmlImage, PmlInput, PmlPageTemplate
 
+if TYPE_CHECKING:
+    from xml.dom.minidom import Element
+
+    from reportlab.platypus.paraparser import ParaFrag
+
+    from xhtml2pdf.context import pisaContext
+    from xhtml2pdf.files import pisaFileObject
+    from xhtml2pdf.parser import AttrContainer
+
 log = logging.getLogger(__name__)
 
 
 def deprecation(message):
-    warnings.warn("<" + message + "> is deprecated!", DeprecationWarning, stacklevel=2)
+    warnings.warn(f"<{message}> is deprecated!", DeprecationWarning, stacklevel=2)
 
 
 class pisaTag:
     """The default class for a tag definition."""
 
-    def __init__(self, node, attr) -> None:
-        self.node = node
-        self.tag = node.tagName
-        self.attr = attr
+    def __init__(self, node: Element, attr: AttrContainer) -> None:
+        self.node: Element = node
+        self.tag: str = node.tagName
+        self.attr: AttrContainer = attr
 
-    @staticmethod
-    def start(c):
+    def start(self, c: pisaContext) -> None:
         pass
 
-    @staticmethod
-    def end(c):
+    def end(self, c: pisaContext) -> None:
         pass
 
 
@@ -75,7 +82,7 @@ class pisaTagBODY(pisaTag):
     in the FONT tag.
     """
 
-    def start(self, c):
+    def start(self, c: pisaContext) -> None:
         c.baseFontSize = c.frag.fontSize
         if "dir" in self.attr and self.attr["dir"]:
             c.setDir(self.attr["dir"])
@@ -83,45 +90,40 @@ class pisaTagBODY(pisaTag):
 
 
 class pisaTagTITLE(pisaTag):
-    @staticmethod
-    def end(c):
+    def end(self, c: pisaContext) -> None:  # noqa: PLR6301
         c.meta["title"] = c.text
         c.clearFrag()
 
 
 class pisaTagSTYLE(pisaTag):
-    @staticmethod
-    def start(c):
+    def start(self, c: pisaContext) -> None:  # noqa: PLR6301
         c.addPara()
 
-    @staticmethod
-    def end(c):
+    def end(self, c: pisaContext) -> None:  # noqa: PLR6301
         c.clearFrag()
 
 
 class pisaTagMETA(pisaTag):
-    def start(self, c):
-        name = self.attr.name.lower()
-        if name in ("author", "subject", "keywords"):
+    def start(self, c: pisaContext) -> None:
+        name: str = self.attr.name.lower()
+        if name in {"author", "subject", "keywords"}:
             c.meta[name] = self.attr.content
 
 
 class pisaTagSUP(pisaTag):
-    @staticmethod
-    def start(c):
+    def start(self, c: pisaContext) -> None:  # noqa: PLR6301
         c.frag.super = 1
 
 
 class pisaTagSUB(pisaTag):
-    @staticmethod
-    def start(c):
+    def start(self, c: pisaContext) -> None:  # noqa: PLR6301
         c.frag.sub = 1
 
 
 class pisaTagA(pisaTag):
     rxLink = r"^(#|[a-z]+\:).*"
 
-    def start(self, c):
+    def start(self, c: pisaContext) -> None:
         attr = self.attr
         # XXX Also support attr.id ?
         if attr.name:
@@ -138,15 +140,14 @@ class pisaTagA(pisaTag):
         if attr.href and re.match(self.rxLink, attr.href):
             c.frag.link = attr.href
 
-    @staticmethod
-    def end(c):
+    def end(self, c: pisaContext) -> None:
         pass
 
 
 class pisaTagFONT(pisaTag):
     # Source: http://www.w3.org/TR/CSS21/fonts.html#propdef-font-size
 
-    def start(self, c):
+    def start(self, c: pisaContext) -> None:
         if self.attr["color"] is not None:
             c.frag.textColor = getColor(self.attr["color"])
         if self.attr["face"] is not None:
@@ -155,13 +156,12 @@ class pisaTagFONT(pisaTag):
             size = getSize(self.attr["size"], c.frag.fontSize, c.baseFontSize)
             c.frag.fontSize = max(size, 1.0)
 
-    @staticmethod
-    def end(c):
+    def end(self, c: pisaContext) -> None:
         pass
 
 
 class pisaTagP(pisaTag):
-    def start(self, c):
+    def start(self, c: pisaContext) -> None:
         # save the type of tag; it's used in PmlBaseDoc.afterFlowable()
         # to check if we need to add an outline-entry
         # c.frag.tag = self.tag
@@ -199,12 +199,12 @@ class pisaTagH6(pisaTagP):
     pass
 
 
-def listDecimal(c):
+def listDecimal(c: pisaContext) -> str:
     c.listCounter += 1
     return str("%d." % c.listCounter)
 
 
-roman_numeral_map = (
+roman_numeral_map: tuple[tuple[int, str], ...] = (
     (1000, "M"),
     (900, "CM"),
     (500, "D"),
@@ -221,44 +221,44 @@ roman_numeral_map = (
 )
 
 
-def int_to_roman(i):
-    result = []
+def int_to_roman(i: int) -> str:
+    result: list[str] = []
     for integer, numeral in roman_numeral_map:
-        count = int(i / integer)
+        count: int = int(i / integer)
         result.append(numeral * count)
         i -= integer * count
     return "".join(result)
 
 
-def listUpperRoman(c):
+def listUpperRoman(c: pisaContext) -> str:
     c.listCounter += 1
-    roman = int_to_roman(c.listCounter)
-    return str("%s." % roman)
+    roman: str = int_to_roman(c.listCounter)
+    return f"{roman}."
 
 
-def listLowerRoman(c):
+def listLowerRoman(c: pisaContext) -> str:
     return listUpperRoman(c).lower()
 
 
-def listUpperAlpha(c):
+def listUpperAlpha(c: pisaContext) -> str:
     c.listCounter += 1
-    index = c.listCounter - 1
+    index: int = c.listCounter - 1
     try:
-        alpha = string.ascii_uppercase[index]
+        alpha: str = string.ascii_uppercase[index]
     except IndexError:
         # needs to start over and double the character
         # this will probably fail for anything past the 2nd time
         alpha = string.ascii_uppercase[index - 26]
         alpha *= 2
-    return str("%s." % alpha)
+    return f"{alpha}."
 
 
-def listLowerAlpha(c):
+def listLowerAlpha(c: pisaContext) -> str:
     return listUpperAlpha(c).lower()
 
 
-_bullet = "\u2022"
-_list_style_type = {
+_bullet: str = "\u2022"
+_list_style_type: dict[str, str | Callable] = {
     "none": "",
     "disc": _bullet,
     "circle": _bullet,  # XXX PDF has no equivalent
@@ -284,7 +284,7 @@ _list_style_type = {
 
 
 class pisaTagUL(pisaTagP):
-    def start(self, c):
+    def start(self, c: pisaContext) -> None:
         self.counter, c.listCounter = c.listCounter, 0
 
     def end(self, c):
@@ -295,17 +295,19 @@ class pisaTagUL(pisaTagP):
 
 
 class pisaTagOL(pisaTagUL):
-    def start(self, c):
+    def start(self, c: pisaContext) -> None:
         start = self.attr.start - 1 if self.attr.start else 0
         self.counter, c.listCounter = c.listCounter, start
 
 
 class pisaTagLI(pisaTag):
-    def start(self, c):
-        lst = _list_style_type.get(c.frag.listStyleType or "disc", _bullet)
-        frag = copy.copy(c.frag)
+    def start(self, c: pisaContext) -> None:
+        lst: str | Callable = _list_style_type.get(
+            c.frag.listStyleType or "disc", _bullet
+        )
+        frag: ParaFrag = copy.copy(c.frag)
 
-        self.offset = 0
+        self.offset: int = 0
         if frag.listStyleImage is not None:
             frag.text = ""
             f = frag.listStyleImage
@@ -330,13 +332,12 @@ class pisaTagLI(pisaTag):
         )
         c.frag.bulletText = [frag]
 
-    def end(self, c):
+    def end(self, c: pisaContext) -> None:
         c.fragBlock.spaceBefore += self.offset
 
 
 class pisaTagBR(pisaTag):
-    @staticmethod
-    def start(c):
+    def start(self, c: pisaContext) -> None:  # noqa: PLR6301
         c.frag.lineBreak = 1
         c.addFrag()
         c.fragStrip = True
@@ -345,13 +346,13 @@ class pisaTagBR(pisaTag):
 
 
 class pisaTagIMG(pisaTag):
-    def start(self, c):
-        attr = self.attr
+    def start(self, c: pisaContext) -> None:
+        attr: AttrContainer = self.attr
         log.debug("Parsing img tag, src: %r", attr.src)
         log.debug("Attrs: %r", attr)
 
         if attr.src:
-            filedata = attr.src.getData()
+            filedata: pisaFileObject = attr.src.getData()
             if filedata:
                 try:
                     align = attr.align or c.frag.vAlign or "baseline"
@@ -436,7 +437,7 @@ class pisaTagIMG(pisaTag):
                         c.fontSize = img.drawHeight
 
                 except Exception:  # TODO: Kill catch-all
-                    log.warning(c.warning("Error in handling image"), exc_info=1)
+                    log.warning(c.warning("Error in handling image"), exc_info=True)
             else:
                 log.warning(c.warning("Need a valid file name!"))
         else:
@@ -444,7 +445,7 @@ class pisaTagIMG(pisaTag):
 
 
 class pisaTagHR(pisaTag):
-    def start(self, c):
+    def start(self, c: pisaContext) -> None:
         c.addPara()
         c.addStory(
             HRFlowable(
@@ -507,8 +508,7 @@ class pisaTagTEXTAREA(pisaTagINPUT):
 
 
 class pisaTagSELECT(pisaTagINPUT):
-    @staticmethod
-    def start(c):
+    def start(self, c: pisaContext) -> None:  # noqa: PLR6301
         c.select_options = ["One", "Two", "Three"]
 
     @staticmethod
@@ -533,7 +533,7 @@ class pisaTagOPTION(pisaTag):
 class pisaTagPDFNEXTPAGE(pisaTag):
     """<pdf:nextpage name="" />."""
 
-    def start(self, c):
+    def start(self, c: pisaContext) -> None:
         c.addPara()
         if self.attr.name:
             c.addStory(NextPageTemplate(self.attr.name))
@@ -543,15 +543,14 @@ class pisaTagPDFNEXTPAGE(pisaTag):
 class pisaTagPDFNEXTTEMPLATE(pisaTag):
     """<pdf:nexttemplate name="" />."""
 
-    def start(self, c):
+    def start(self, c: pisaContext) -> None:
         c.addStory(NextPageTemplate(self.attr["name"]))
 
 
 class pisaTagPDFNEXTFRAME(pisaTag):
     """<pdf:nextframe name="" />."""
 
-    @staticmethod
-    def start(c):
+    def start(self, c: pisaContext) -> None:  # noqa: PLR6301
         c.addPara()
         c.addStory(FrameBreak())
 
@@ -559,7 +558,7 @@ class pisaTagPDFNEXTFRAME(pisaTag):
 class pisaTagPDFSPACER(pisaTag):
     """<pdf:spacer height="" />."""
 
-    def start(self, c):
+    def start(self, c: pisaContext) -> None:
         c.addPara()
         c.addStory(Spacer(1, self.attr.height))
 
@@ -567,8 +566,7 @@ class pisaTagPDFSPACER(pisaTag):
 class pisaTagPDFPAGENUMBER(pisaTag):
     """<pdf:pagenumber example="" />."""
 
-    @staticmethod
-    def start(c):
+    def start(self, c: pisaContext) -> None:  # noqa: PLR6301
         flow = PageNumberFlowable()
         pn = c.addPageNumber(flow)
         c.addStory(flow)
@@ -580,8 +578,7 @@ class pisaTagPDFPAGENUMBER(pisaTag):
 class pisaTagPDFPAGECOUNT(pisaTag):
     """<pdf:pagecount />."""
 
-    @staticmethod
-    def start(c):
+    def start(self, c: pisaContext) -> None:  # noqa: PLR6301
         flow = PageNumberFlowable()
         pc = c.getPageCount(flow)
         c.addStory(flow)
@@ -589,16 +586,14 @@ class pisaTagPDFPAGECOUNT(pisaTag):
         c.addFrag(pc)
         c.frag.pageCount = False
 
-    @staticmethod
-    def end(c):
+    def end(self, c: pisaContext) -> None:  # noqa: PLR6301
         c.addPageCount()
 
 
 class pisaTagPDFTOC(pisaTag):
     """<pdf:toc />."""
 
-    @staticmethod
-    def end(c):
+    def end(self, c: pisaContext) -> None:  # noqa: PLR6301
         c.multiBuild = True
         c.addTOC()
 
@@ -606,7 +601,7 @@ class pisaTagPDFTOC(pisaTag):
 class pisaTagPDFFRAME(pisaTag):
     """<pdf:frame name="" static box="" />."""
 
-    def start(self, c):
+    def start(self, c: pisaContext) -> None:
         deprecation("pdf:frame")
         attrs = self.attr
 
@@ -651,7 +646,7 @@ class pisaTagPDFTEMPLATE(pisaTag):
     </pdf:template>.
     """
 
-    def start(self, c):
+    def start(self, c: pisaContext) -> None:
         deprecation("pdf:template")
         attrs = self.attr
         name = attrs["name"]
@@ -680,14 +675,14 @@ class pisaTagPDFTEMPLATE(pisaTag):
 class pisaTagPDFLANGUAGE(pisaTag):
     """<pdf:language name=""/>."""
 
-    def start(self, c):
+    def start(self, c: pisaContext) -> None:
         c.language = self.attr.name
 
 
 class pisaTagPDFFONT(pisaTag):
     """<pdf:fontembed name="" src="" />."""
 
-    def start(self, c):
+    def start(self, c: pisaContext) -> None:
         deprecation("pdf:font")
         c.loadFont(self.attr.name, self.attr.src, self.attr.encoding)
 
@@ -738,7 +733,7 @@ class pisaTagPDFBARCODE(pisaTag):
         def wrap(self, aW, aH):
             return self.widget.wrap(aW, aH)
 
-    def start(self, c):
+    def start(self, c: pisaContext) -> None:
         attr = self.attr
         codeName = attr.type or "Code128"
         codeName = pisaTagPDFBARCODE._codeName[codeName.upper().replace("-", "")]
@@ -802,8 +797,7 @@ class pisaTagCANVAS(pisaTag):
             "legendedPie": LegendedPieChart,
         }
 
-    @staticmethod
-    def start(c):
+    def start(self, c: pisaContext) -> None:
         pass
 
     def end(self, c):

--- a/xhtml2pdf/util.py
+++ b/xhtml2pdf/util.py
@@ -265,7 +265,7 @@ def getSize(value, relative=0, base=None, default=0.0):
             return default  # value = 0
         return max(0, value)
     except Exception:
-        log.warning("getSize %r %r", original, relative, exc_info=1)
+        log.warning("getSize %r %r", original, relative, exc_info=True)
         return default
 
 

--- a/xhtml2pdf/xhtml2pdf_reportlab.py
+++ b/xhtml2pdf/xhtml2pdf_reportlab.py
@@ -474,6 +474,7 @@ class PmlImage(Flowable, PmlMaxHeightMixIn):
     def __init__(
         self,
         data: pisaFileObject,
+        src: str | None = None,
         width: int | None = None,
         height: int | None = None,
         mask: str = "auto",
@@ -486,6 +487,7 @@ class PmlImage(Flowable, PmlMaxHeightMixIn):
         self._imgdata: bytes = (
             data.getvalue() if isinstance(data, pisaTempFile) else data
         )
+        self.src: str | None = src
         # print "###", repr(data)
         self.mimetype: str | None = mimetype
 

--- a/xhtml2pdf/xhtml2pdf_reportlab.py
+++ b/xhtml2pdf/xhtml2pdf_reportlab.py
@@ -536,17 +536,22 @@ class PmlImage(Flowable, PmlMaxHeightMixIn):
                 # Apply size
                 scale_x = 1
                 scale_y = 1
-                if getattr(self, "drawWidth", None) is not None:
-                    if width is None:
-                        width = self.drawWidth
-                    scale_x = width / drawing.width
-                if getattr(self, "drawHeight", None) is not None:
-                    if height is None:
-                        height = self.drawHeight
-                    scale_y = height / drawing.height
-                if scale_x != 1 or scale_y != 1:
-                    drawing.scale(scale_x, scale_y)
-
+                try:
+                    if getattr(self, "drawWidth", None) is not None:
+                        if width is None:
+                            width = self.drawWidth
+                        scale_x = width / drawing.width
+                    if getattr(self, "drawHeight", None) is not None:
+                        if height is None:
+                            height = self.drawHeight
+                        scale_y = height / drawing.height
+                    if scale_x != 1 or scale_y != 1:
+                        drawing.scale(scale_x, scale_y)
+                except ZeroDivisionError:
+                    log.warning(
+                        "SVG drawing could not be resized: %r",
+                        self.src or self._imgdata[:50],
+                    )
                 return drawing
         return None
 


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This error happened on images where the width could not be correctly identified:
```
Traceback (most recent call last):
  File "/home/xhtml2pdf/document.py", line 196, in pisaDocument
    doc.build(context.story)
  File "/home/.venv/lib/python3.11/site-packages/reportlab/platypus/doctemplate.py", line 1082, in build
    self.handle_flowable(flowables)
  File "/home/.venv/lib/python3.11/site-packages/reportlab/platypus/doctemplate.py", line 931, in handle_flowable
    if frame.add(f, canv, trySplit=self.allowSplitting):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/.venv/lib/python3.11/site-packages/reportlab/platypus/frames.py", line 212, in _add
    flowable.drawOn(canv, self._x + self._leftExtraIndent, y, _sW=aW-w)
  File "/home/.venv/lib/python3.11/site-packages/reportlab/platypus/flowables.py", line 112, in drawOn
    self._drawOn(canvas)
  File "/home/.venv/lib/python3.11/site-packages/reportlab/platypus/flowables.py", line 93, in _drawOn
    self.draw()#this is the bit you overload
    ^^^^^^^^^^^
  File "/home/xhtml2pdf/xhtml2pdf_reportlab.py", line 716, in draw
    Paragraph.draw(self)
  File "/home/xhtml2pdf/reportlab_paragraph.py", line 1212, in draw
    self.drawPara(self.debug)
  File "/home/xhtml2pdf/reportlab_paragraph.py", line 1769, in drawPara
    dpl(tx, offset, lines[0], noJustifyLast and nLines == 1)
  File "/home/xhtml2pdf/reportlab_paragraph.py", line 379, in _leftDrawParaLineX
    _putFragLine(offset, tx, line)
  File "/home/xhtml2pdf/reportlab_paragraph.py", line 219, in _putFragLine
    drawing = cbDefn.image.getDrawing(w, h)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/xhtml2pdf/xhtml2pdf_reportlab.py", line 538, in getDrawing
    scale_x = width / drawing.width
              ~~~~~~^~~~~~~~~~~~~~~
ZeroDivisionError: float division by zero
```
