### PR TITLE
Only include xhtml2pdf package in wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ xhtml2pdf = "xhtml2pdf.pisa:command"
 version = {attr = "xhtml2pdf.__version__"}
 
 [tool.setuptools.packages.find]
-exclude = ["tests", "tests.*", "manual_test", "manual_test.*"]
+include = ["xhtml2pdf*"]
 
 
 [tool.tox]


### PR DESCRIPTION
Previously, the wheel included these top-level packages in addition to xhtml2pdf:

* demo
* docs
* testrender

Resolves #736.