### PR TITLE
reportlab Compatibility: Adapt to New ShowBoundaryValue Import

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ dependencies = [
     "pyhanko-certvalidator>=0.19.5",
     "pypdf>=3.1.0",
     "python-bidi>=0.4.2",
-    "reportlab>=4.0.4",
+    "reportlab>=4.0.4,<5",
     "svglib>=1.2.1",
 ]
 dynamic = ["version"]
@@ -67,10 +67,10 @@ Changelog = "https://xhtml2pdf.readthedocs.io/en/latest/release-notes.html"
 
 [project.optional-dependencies]
 pycairo = [
-    "reportlab[pycairo]>=4.0.4",
+    "reportlab[pycairo]>=4.0.4,<5",
 ]
 renderpm = [
-    "reportlab[renderpm]>=4.0.4",
+    "reportlab[renderpm]>=4.0.4,<5",
 ]
 test = [
     "tomli>=2.0.1; python_version<'3.11'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ dependencies = [
     "pyhanko-certvalidator>=0.19.5",
     "pypdf>=3.1.0",
     "python-bidi>=0.4.2",
-    "reportlab>=4.0.4,<4.1",
+    "reportlab>=4.0.4",
     "svglib>=1.2.1",
 ]
 dynamic = ["version"]
@@ -67,10 +67,10 @@ Changelog = "https://xhtml2pdf.readthedocs.io/en/latest/release-notes.html"
 
 [project.optional-dependencies]
 pycairo = [
-    "reportlab[pycairo]>=4.0.4,<4.1",
+    "reportlab[pycairo]>=4.0.4",
 ]
 renderpm = [
-    "reportlab[renderpm]>=4.0.4,<4.1",
+    "reportlab[renderpm]>=4.0.4",
 ]
 test = [
     "tomli>=2.0.1; python_version<'3.11'",

--- a/xhtml2pdf/context.py
+++ b/xhtml2pdf/context.py
@@ -27,8 +27,13 @@ from reportlab.lib.pagesizes import A4
 from reportlab.lib.styles import ParagraphStyle
 from reportlab.pdfbase import pdfmetrics
 from reportlab.pdfbase.ttfonts import TTFont
-from reportlab.platypus.frames import Frame, ShowBoundaryValue
+from reportlab.platypus.frames import Frame
 from reportlab.platypus.paraparser import ParaFrag, ps2tt, tt2ps
+try:
+    from reportlab.pdfgen.canvas import ShowBoundaryValue
+except ImportError:
+    # reportlab < 4.0.9.1
+    from reportlab.platypus.frames import ShowBoundaryValue
 
 from xhtml2pdf import default, parser
 from xhtml2pdf.files import getFile, pisaFileObject

--- a/xhtml2pdf/context.py
+++ b/xhtml2pdf/context.py
@@ -28,12 +28,13 @@ from reportlab.lib.styles import ParagraphStyle
 from reportlab.pdfbase import pdfmetrics
 from reportlab.pdfbase.ttfonts import TTFont
 from reportlab.platypus.frames import Frame
-from reportlab.platypus.paraparser import ParaFrag, ps2tt, tt2ps
+
 try:
     from reportlab.pdfgen.canvas import ShowBoundaryValue
 except ImportError:
     # reportlab < 4.0.9.1
     from reportlab.platypus.frames import ShowBoundaryValue
+from reportlab.platypus.paraparser import ParaFrag, ps2tt, tt2ps
 
 from xhtml2pdf import default, parser
 from xhtml2pdf.files import getFile, pisaFileObject


### PR DESCRIPTION
### Short description

Fix compatibility with `reportlab>=4.0.9.1`.


### Proposed changes

- Use new import if possible.
- Fallback to old import if required.


### Resolved issues

Fixes: #751 (cleanly)
