### PR TITLE
#770 python-bidi module import fix

### DIFF
--- a/xhtml2pdf/util.py
+++ b/xhtml2pdf/util.py
@@ -22,7 +22,7 @@ from typing import Any
 import arabic_reshaper
 import reportlab
 import reportlab.pdfbase._cidfontdata
-from bidi.algorithm import get_display
+from bidi import get_display
 from reportlab.lib.colors import Color, toColor
 from reportlab.lib.enums import TA_CENTER, TA_JUSTIFY, TA_LEFT, TA_RIGHT
 from reportlab.lib.units import cm, inch


### PR DESCRIPTION
fixed the import with new version release of python-bidi package

### Short description
<!-- Describe this PR in one or two sentences. -->
updated the import with new version of python-bidi package
python-bidi latest version: 0.5.0

### Proposed changes
<!-- Describe this PR in more detail. -->
xhtml2pdf/util.py line 25

`from bidi.algorithm import get_display`  with
`from bidi import get_display `



### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #770 
