### PR TITLE
Pylint fixes

### DIFF
--- a/demo/cherrypy/demo-cherrypy.py
+++ b/demo/cherrypy/demo-cherrypy.py
@@ -27,7 +27,7 @@ class PDFDemo:
     @staticmethod
     def index():
         if kid:
-            with open("demo-cherrypy.html") as file:
+            with open("demo-cherrypy.html", encoding="utf-8") as file:
                 return file.read()
 
         return """

--- a/docs/source/build_samples.py
+++ b/docs/source/build_samples.py
@@ -57,7 +57,7 @@ Examples
                     name,
                     filename,
                 )
-    with open(rst_path / "examples.rst", "w") as arch:
+    with open(rst_path / "examples.rst", "w", encoding="utf-8") as arch:
         arch.write(text)
 
 

--- a/manual_test/linkloading.py
+++ b/manual_test/linkloading.py
@@ -65,7 +65,7 @@ class myLinkLoader:
         try:
             if "." in path:
                 new_suffix = "." + path.split(".")[-1].lower()
-                if new_suffix in (".css", ".gif", ".jpg", ".png"):
+                if new_suffix in {".css", ".gif", ".jpg", ".png"}:
                     suffix = new_suffix
             tmpPath = tempfile.mktemp(prefix="pisa-", suffix=suffix)
             with open(tmpPath, "wb") as tmpFile:

--- a/manual_test/simple.py
+++ b/manual_test/simple.py
@@ -73,7 +73,7 @@ def testBackgroundAndImage(src="test-background.html", dest="test-background.pdf
     PML Source String. Also shows errors and tries to start
     the resulting PDF.
     """
-    with open(src) as src_file, open(dest, "wb") as dst_file:
+    with open(src, encoding="utf-8") as src_file, open(dest, "wb") as dst_file:
         pdf = pisa.CreatePDF(
             src_file,
             dst_file,

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -200,7 +200,7 @@ class DocumentTest(TestCase):
         tests_folder = os.path.dirname(os.path.realpath(__file__))
         html_path = os.path.join(tests_folder, "samples", "nested_table.html")
 
-        with open(html_path) as html_file:
+        with open(html_path, encoding="utf-8") as html_file:
             html = html_file.read()
 
         with tempfile.TemporaryFile() as pdf_file:

--- a/xhtml2pdf/charts.py
+++ b/xhtml2pdf/charts.py
@@ -27,7 +27,7 @@ class Props:
             ("width", int),
             ("height", int),
             ("data", lambda x: x),
-            ("labels", lambda x: instance.assign_labels(x)),
+            ("labels", instance.assign_labels),
         ]
         self.prop_map_title = [("x", int), ("y", int), ("_text", str)]
         self.prop_map_legend = [

--- a/xhtml2pdf/context.py
+++ b/xhtml2pdf/context.py
@@ -199,14 +199,14 @@ class pisaCSSBuilder(css.CSSBuilder):
 
         # Font weight
         fweight = str(data.get("font-weight", "normal")).lower()
-        bold = fweight in ("bold", "bolder", "500", "600", "700", "800", "900")
+        bold = fweight in {"bold", "bolder", "500", "600", "700", "800", "900"}
         if not bold and fweight != "normal":
             log.warning(
                 self.c.warning("@fontface, unknown value font-weight '%s'", fweight)
             )
 
         # Font style
-        italic = str(data.get("font-style", "")).lower() in ("italic", "oblique")
+        italic = str(data.get("font-style", "")).lower() in {"italic", "oblique"}
 
         # The "src" attribute can be a CSS group but in that case
         # ignore everything except the font URI
@@ -1090,7 +1090,7 @@ class pisaContext:
             baseName, suffix = ".".join(parts[:-1]), parts[-1]
             suffix = suffix.lower()
 
-            if suffix in ["ttc", "ttf"]:
+            if suffix in {"ttc", "ttf"}:
                 # determine full font name according to weight and style
                 fullFontName = "%s_%d%d" % (fontName, bold, italic)
 
@@ -1118,7 +1118,7 @@ class pisaContext:
                     # Register "normal" name and the place holder for style
                     self.registerFont(fontName, [*fontAlias, fullFontName])
 
-            elif suffix in ("afm", "pfb"):
+            elif suffix in {"afm", "pfb"}:
                 if suffix == "afm":
                     afm = file.getNamedFile()
                     tfile = pisaFileObject(baseName + ".pfb", basepath=file.basepath)

--- a/xhtml2pdf/files.py
+++ b/xhtml2pdf/files.py
@@ -310,7 +310,7 @@ class LocalFileURI(BaseFile):
             self.suffix = uri.suffix
             self.mimetype = self.guess_mimetype(uri)
             if self.mimetype and self.mimetype.startswith("text"):
-                with open(uri) as file_handler:
+                with open(uri, encoding="utf-8") as file_handler:
                     data = file_handler.read().encode("utf-8")
             else:
                 with open(uri, "rb") as file_handler:
@@ -364,7 +364,7 @@ class FileNetworkManager:
             log.debug("URLParts: %r, %r", urlParts, urlParts.scheme)
             if urlParts.scheme == "file":
                 instance = LocalProtocolURI(uri, basepath)
-            elif urlParts.scheme in ("http", "https"):
+            elif urlParts.scheme in {"http", "https"}:
                 instance = NetworkFileUri(uri, basepath)
             else:
                 instance = LocalFileURI(uri, basepath)

--- a/xhtml2pdf/paragraph.py
+++ b/xhtml2pdf/paragraph.py
@@ -401,7 +401,7 @@ class Text(list):
                 line.append(frag)
 
             # Remove trailing white spaces
-            while line and line[-1].name in ("space", "br"):
+            while line and line[-1].name in {"space", "br"}:
                 line.pop()
 
             # Add line to list

--- a/xhtml2pdf/parser.py
+++ b/xhtml2pdf/parser.py
@@ -411,7 +411,7 @@ def CSS2Frag(c, kw, isBlock):
         except TypeError:
             # sequence item 0: expected string, tuple found
             c.frag.height = "".join(toList(c.cssAttr["height"][0]))
-        if c.frag.height in {"auto",}:
+        if c.frag.height in {"auto"}:
             c.frag.height = None
     if "width" in c.cssAttr:
         try:
@@ -419,7 +419,7 @@ def CSS2Frag(c, kw, isBlock):
             c.frag.width = "".join(toList(c.cssAttr["width"]))
         except TypeError:
             c.frag.width = "".join(toList(c.cssAttr["width"][0]))
-        if c.frag.width in {"auto",}:
+        if c.frag.width in {"auto"}:
             c.frag.width = None
         # ZOOM
     if "zoom" in c.cssAttr:

--- a/xhtml2pdf/parser.py
+++ b/xhtml2pdf/parser.py
@@ -166,7 +166,7 @@ def pisaGetAttributes(c, tag, attributes):
 
                 elif v == BOOL:
                     nv = nv.strip().lower()
-                    nv = nv in ("1", "y", "yes", "true", str(k))
+                    nv = nv in {"1", "y", "yes", "true", str(k)}
 
                 elif v == SIZE:
                     try:
@@ -377,7 +377,7 @@ def CSS2Frag(c, kw, isBlock):
         # print "line-spacing", c.cssAttr["-pdf-line-spacing"], c.frag.leading
     if "font-weight" in c.cssAttr:
         value = lower(c.cssAttr["font-weight"])
-        if value in ("bold", "bolder", "500", "600", "700", "800", "900"):
+        if value in {"bold", "bolder", "500", "600", "700", "800", "900"}:
             c.frag.bold = 1
         else:
             c.frag.bold = 0
@@ -391,7 +391,7 @@ def CSS2Frag(c, kw, isBlock):
             c.frag.strike = 0
     if "font-style" in c.cssAttr:
         value = lower(c.cssAttr["font-style"])
-        if value in ("italic", "oblique"):
+        if value in {"italic", "oblique"}:
             c.frag.italic = 1
         else:
             c.frag.italic = 0
@@ -411,7 +411,7 @@ def CSS2Frag(c, kw, isBlock):
         except TypeError:
             # sequence item 0: expected string, tuple found
             c.frag.height = "".join(toList(c.cssAttr["height"][0]))
-        if c.frag.height in ("auto",):
+        if c.frag.height in {"auto",}:
             c.frag.height = None
     if "width" in c.cssAttr:
         try:
@@ -419,7 +419,7 @@ def CSS2Frag(c, kw, isBlock):
             c.frag.width = "".join(toList(c.cssAttr["width"]))
         except TypeError:
             c.frag.width = "".join(toList(c.cssAttr["width"][0]))
-        if c.frag.width in ("auto",):
+        if c.frag.width in {"auto",}:
             c.frag.width = None
         # ZOOM
     if "zoom" in c.cssAttr:
@@ -517,11 +517,11 @@ def pisaPreLoop(node, context, *, collect=False):
     elif node.nodeType == Node.ELEMENT_NODE:
         name = node.tagName.lower()
 
-        if name in ("style", "link"):
+        if name in {"style", "link"}:
             attr = pisaGetAttributes(context, name, node.attributes)
             media = [x.strip() for x in attr.media.lower().split(",") if x.strip()]
 
-            if attr.get("type", "").lower() in ("", "text/css") and (
+            if attr.get("type", "").lower() in {"", "text/css"} and (
                 not media or "all" in media or "print" in media or "pdf" in media
             ):
                 if name == "style":
@@ -566,7 +566,7 @@ def pisaLoop(node, context, path=None, **kw):
     elif node.nodeType == Node.ELEMENT_NODE:
         node.tagName = node.tagName.replace(":", "").lower()
 
-        if node.tagName in ("style", "script"):
+        if node.tagName in {"style", "script"}:
             return
 
         path = [*copy.copy(path), node.tagName]
@@ -664,7 +664,7 @@ def pisaLoop(node, context, path=None, **kw):
         keepInFrameMaxHeight = 0
         if "-pdf-keep-in-frame-mode" in context.cssAttr:
             value = str(context.cssAttr["-pdf-keep-in-frame-mode"]).strip().lower()
-            if value in ("shrink", "error", "overflow", "truncate"):
+            if value in {"shrink", "error", "overflow", "truncate"}:
                 keepInFrameMode = value
             else:
                 keepInFrameMode = "shrink"

--- a/xhtml2pdf/pisa.py
+++ b/xhtml2pdf/pisa.py
@@ -214,7 +214,7 @@ def execute():
             usage()
             sys.exit()
 
-        elif o in {"--version",}:
+        elif o in {"--version"}:
             print(__version__)
             sys.exit(0)
 
@@ -222,7 +222,7 @@ def execute():
             print(COPYRIGHT)
             sys.exit(0)
 
-        elif o in {"--system",}:
+        elif o in {"--system"}:
             print(COPYRIGHT)
             print()
             print("SYSTEM INFORMATIONS")
@@ -262,7 +262,7 @@ def execute():
         elif o in {"-b", "--base"}:
             base_dir = a
 
-        elif o in {"--encoding",} and a:
+        elif o in {"--encoding"} and a:
             # Encoding
             encoding = a
 
@@ -271,18 +271,18 @@ def execute():
             with open(a, encoding="utf-8") as file_handler:
                 css = file_handler.read()
 
-        elif o in {"--css-dump",}:
+        elif o in {"--css-dump"}:
             # CSS dump
             print(DEFAULT_CSS)
             return
 
-        elif o in {"--xml-dump",}:
+        elif o in {"--xml-dump"}:
             xml_output = sys.stdout
 
         elif o in {"-x", "--xml", "--xhtml"}:
             xhtml = True
 
-        elif o in {"--html",}:
+        elif o in {"--html"}:
             xhtml = False
 
         elif httpConfig.is_http_config(o, a):

--- a/xhtml2pdf/pisa.py
+++ b/xhtml2pdf/pisa.py
@@ -209,12 +209,12 @@ def execute():
     log_format = LOG_FORMAT
 
     for o, a in opts:
-        if o in ("-h", "--help"):
+        if o in {"-h", "--help"}:
             # Hilfe anzeigen
             usage()
             sys.exit()
 
-        elif o in ("--version",):
+        elif o in {"--version",}:
             print(__version__)
             sys.exit(0)
 
@@ -222,7 +222,7 @@ def execute():
             print(COPYRIGHT)
             sys.exit(0)
 
-        elif o in ("--system",):
+        elif o in {"--system",}:
             print(COPYRIGHT)
             print()
             print("SYSTEM INFORMATIONS")
@@ -235,19 +235,19 @@ def execute():
             print("Reportlab:         %s" % reportlab.Version)
             sys.exit(0)
 
-        elif o in ("-s", "--start-viewer", "--start"):
+        elif o in {"-s", "--start-viewer", "--start"}:
             # Anzeigeprogramm starten
             startviewer = 1
 
-        elif o in ("-q", "--quiet"):
+        elif o in {"-q", "--quiet"}:
             # Output unterdr�cken
             quiet = 1
 
-        elif o in ("-w", "--warn"):
+        elif o in {"-w", "--warn"}:
             # Warnings
             log_level = min(log_level, logging.WARNING)  # If also -d ignore -w
 
-        elif o in ("-d", "--debug"):
+        elif o in {"-d", "--debug"}:
             # Debug
             log_level = logging.DEBUG
             log_format = LOG_FORMAT_DEBUG
@@ -255,34 +255,34 @@ def execute():
             if a:
                 log_level = int(a)
 
-        elif o in ("-t", "--format"):
+        elif o in {"-t", "--format"}:
             # Format XXX ???
             file_format = a
 
-        elif o in ("-b", "--base"):
+        elif o in {"-b", "--base"}:
             base_dir = a
 
-        elif o in ("--encoding",) and a:
+        elif o in {"--encoding",} and a:
             # Encoding
             encoding = a
 
-        elif o in ("-c", "--css"):
+        elif o in {"-c", "--css"}:
             # CSS
-            with open(a) as file_handler:
+            with open(a, encoding="utf-8") as file_handler:
                 css = file_handler.read()
 
-        elif o in ("--css-dump",):
+        elif o in {"--css-dump",}:
             # CSS dump
             print(DEFAULT_CSS)
             return
 
-        elif o in ("--xml-dump",):
+        elif o in {"--xml-dump",}:
             xml_output = sys.stdout
 
-        elif o in ("-x", "--xml", "--xhtml"):
+        elif o in {"-x", "--xml", "--xhtml"}:
             xhtml = True
 
-        elif o in ("--html",):
+        elif o in {"--html",}:
             xhtml = False
 
         elif httpConfig.is_http_config(o, a):
@@ -291,7 +291,7 @@ def execute():
     if not quiet:
         logging.basicConfig(level=log_level, format=log_format)
 
-    if len(args) not in (1, 2):
+    if len(args) not in {1, 2}:
         usage()
         sys.exit(2)
 

--- a/xhtml2pdf/reportlab_paragraph.py
+++ b/xhtml2pdf/reportlab_paragraph.py
@@ -144,11 +144,11 @@ def imgVRange(h, va, fontSize):
     """Return bottom,top offsets relative to baseline(0)."""
     if va == "baseline":
         iyo = 0
-    elif va in ("text-top", "top"):
+    elif va in {"text-top", "top"}:
         iyo = fontSize - h
     elif va == "middle":
         iyo = fontSize - (1.2 * fontSize + h) * 0.5
-    elif va in ("text-bottom", "bottom"):
+    elif va in {"text-bottom", "bottom"}:
         iyo = fontSize - 1.2 * fontSize
     elif va == "super":
         iyo = 0.5 * fontSize
@@ -172,7 +172,7 @@ def _putFragLine(cur_x, tx, line):
     autoLeading = xs.autoLeading
     leading = xs.leading
     cur_x += xs.leftIndent
-    dal = autoLeading in ("min", "max")
+    dal = autoLeading in {"min", "max"}
     if dal:
         if autoLeading == "max":
             ascent = max(_56 * leading, line.ascent)
@@ -608,7 +608,7 @@ def _handleBulletWidth(bulletText, style, maxWidths):
             # it's a list of fragments
             bulletWidth = 0
             for f in bulletText:
-                bulletWidth = bulletWidth + stringWidth(f.text, f.fontName, f.fontSize)
+                bulletWidth += stringWidth(f.text, f.fontName, f.fontSize)
         bulletRight = style.bulletIndent + bulletWidth + 0.6 * style.bulletFontSize
         indent = style.leftIndent + style.firstLineIndent
         if bulletRight > indent:
@@ -664,7 +664,7 @@ def splitLines0(frags, widths):
             w = stringWidth(text[start:j], f.fontName, f.fontSize)
             cLen += w
             if cLen > maxW and line != []:
-                cLen = cLen - w
+                cLen -= w
                 # this is the end of the line
                 while g.text[lim] == " ":
                     lim -= 1
@@ -1076,7 +1076,7 @@ class Paragraph(Flowable):
         self.blPara = blPara
         autoLeading = getattr(self, "autoLeading", getattr(style, "autoLeading", ""))
         leading = style.leading
-        if blPara.kind == 1 and autoLeading not in ("", "off"):
+        if blPara.kind == 1 and autoLeading not in {"", "off"}:
             height = 0
             if autoLeading == "max":
                 for line in blPara.lines:
@@ -1138,7 +1138,7 @@ class Paragraph(Flowable):
         autoLeading = getattr(self, "autoLeading", getattr(style, "autoLeading", ""))
         leading = style.leading
         lines = blPara.lines
-        if blPara.kind == 1 and autoLeading not in ("", "off"):
+        if blPara.kind == 1 and autoLeading not in {"", "off"}:
             s = height = 0
             if autoLeading == "max":
                 for i, line in enumerate(blPara.lines):
@@ -1257,7 +1257,7 @@ class Paragraph(Flowable):
 
         self.height = 0
         autoLeading = getattr(self, "autoLeading", getattr(style, "autoLeading", ""))
-        calcBounds = autoLeading not in ("", "off")
+        calcBounds = autoLeading not in {"", "off"}
         frags = self.frags
         nFrags = len(frags)
         if nFrags == 1 and not hasattr(frags[0], "cbDefn"):
@@ -1278,8 +1278,7 @@ class Paragraph(Flowable):
                     cLine.append(word)
                     currentWidth = newWidth
                 else:
-                    if currentWidth > self.width:
-                        self.width = currentWidth
+                    self.width = max(currentWidth, self.width)
                     # end of line
                     lines.append((maxWidth - currentWidth, cLine))
                     cLine = [word]
@@ -1292,8 +1291,7 @@ class Paragraph(Flowable):
 
             # deal with any leftovers on the final line
             if cLine != []:
-                if currentWidth > self.width:
-                    self.width = currentWidth
+                self.width = max(currentWidth, self.width)
                 lines.append((maxWidth - currentWidth, cLine))
 
             return f.clone(
@@ -1420,8 +1418,7 @@ class Paragraph(Flowable):
                     g = f.clone()
                     words.append(g)
 
-                if currentWidth > self.width:
-                    self.width = currentWidth
+                self.width = max(currentWidth, self.width)
                 # end of line
                 lines.append(
                     FragLine(
@@ -1485,8 +1482,7 @@ class Paragraph(Flowable):
 
         # deal with any leftovers on the final line
         if words != []:
-            if currentWidth > self.width:
-                self.width = currentWidth
+            self.width = max(currentWidth, self.width)
             lines.append(
                 ParaLines(
                     extraSpace=(maxWidth - currentWidth),
@@ -1516,7 +1512,7 @@ class Paragraph(Flowable):
             autoLeading = getattr(
                 self, "autoLeading", getattr(style, "autoLeading", "")
             )
-            calcBounds = autoLeading not in ("", "off")
+            calcBounds = autoLeading not in {"", "off"}
             return cjkFragSplit(self.frags, maxWidths, calcBounds, self.encoding)
 
         if not len(self.frags):

--- a/xhtml2pdf/tables.py
+++ b/xhtml2pdf/tables.py
@@ -338,7 +338,7 @@ class pisaTagTD(pisaTag):
         # Calculate widths
         # Add empty placeholders for new columns
         if (col + 1) > len(tdata.colw):
-            tdata.colw = tdata.colw + ((col + 1 - len(tdata.colw)) * [_width()])
+            tdata.colw += (col + 1 - len(tdata.colw)) * [_width()]
 
         # Get value of with, if no spanning
         if not cspan:
@@ -364,7 +364,7 @@ class pisaTagTD(pisaTag):
 
         # Calculate heights
         if row + 1 > len(tdata.rowh):
-            tdata.rowh = tdata.rowh + ((row + 1 - len(tdata.rowh)) * [_width()])
+            tdata.rowh += (row + 1 - len(tdata.rowh)) * [_width()]
         if not rspan:
             height = c.frag.height or self.attr.get("height", None)
             if height is not None:

--- a/xhtml2pdf/tags.py
+++ b/xhtml2pdf/tags.py
@@ -404,7 +404,7 @@ class pisaTagIMG(pisaTag):
                     """
 
                     c.force = True
-                    if align in ["left", "right"]:
+                    if align in {"left", "right"}:
                         c.image = img
                         c.imageData = {"align": align}
 
@@ -414,11 +414,11 @@ class pisaTagIMG(pisaTag):
                         # afrag = c.frag.clone()
 
                         valign = align
-                        if valign in ["texttop"]:
+                        if valign in {"texttop"}:
                             valign = "top"
-                        elif valign in ["absmiddle"]:
+                        elif valign in {"absmiddle"}:
                             valign = "middle"
-                        elif valign in ["absbottom", "baseline"]:
+                        elif valign in {"absbottom", "baseline"}:
                             valign = "bottom"
 
                         afrag = c.frag.clone()
@@ -753,7 +753,7 @@ class pisaTagPDFBARCODE(pisaTag):
         fontSize: float = attr.fontsize or 2.75 * mm
 
         # Assure minimal size.
-        if codeName in ("EAN13", "EAN8"):
+        if codeName in {"EAN13", "EAN8"}:
             barWidth = max(barWidth, 0.264 * mm)
             fontSize = max(fontSize, 2.75 * mm)
         else:  # Code39 etc.
@@ -775,11 +775,11 @@ class pisaTagPDFBARCODE(pisaTag):
         c.force = True
 
         valign = attr.align or c.frag.vAlign or "baseline"
-        if valign in ["texttop"]:
+        if valign in {"texttop"}:
             valign = "top"
-        elif valign in ["absmiddle"]:
+        elif valign in {"absmiddle"}:
             valign = "middle"
-        elif valign in ["absbottom", "baseline"]:
+        elif valign in {"absbottom", "baseline"}:
             valign = "bottom"
 
         afrag = c.frag.clone()

--- a/xhtml2pdf/util.py
+++ b/xhtml2pdf/util.py
@@ -154,7 +154,7 @@ def getColor(value, default=None):
 
 
 def getBorderStyle(value, default=None):
-    if value and (str(value).lower() not in ("none", "hidden")):
+    if value and (str(value).lower() not in {"none", "hidden"}):
         return value
     return default
 
@@ -237,7 +237,7 @@ def getSize(
             # XXX W3C says, use 96pdi
             # http://www.w3.org/TR/CSS21/syndata.html#length-units
             return float(value[:-2].strip()) * DPI96
-        if value in ("none", "0", "0.0", "auto"):
+        if value in {"none", "0", "0.0", "auto"}:
             return 0.0
         if relative:
             if value.endswith("rem"):  # XXX
@@ -366,7 +366,7 @@ def getPos(position, pagesize):
 
 def getBool(s):
     """Is it a boolean?."""
-    return str(s).lower() in ("y", "yes", "1", "true")
+    return str(s).lower() in {"y", "yes", "1", "true"}
 
 
 def getFloat(s):
@@ -601,14 +601,14 @@ def arabic_format(text, language):
     # Note: right now all of the languages are treated the same way.
     # But maybe in the future we have to for example implement something
     # for "hebrew" that isn't used in "arabic"
-    if detect_language(language) in (
+    if detect_language(language) in {
         "arabic",
         "hebrew",
         "persian",
         "urdu",
         "pashto",
         "sindhi",
-    ):
+    }:
         ar = arabic_reshaper.reshape(text)
         return get_display(ar)
     return None

--- a/xhtml2pdf/w3c/css.py
+++ b/xhtml2pdf/w3c/css.py
@@ -308,10 +308,10 @@ class CSSSelectorBase:
             return False
 
         # with  CSSDOMElementInterface.matchesNode(self, (namespace, tagName)) replacement:
-        if self.fullName[1] not in ("*", element.domElement.tagName):
+        if self.fullName[1] not in {"*", element.domElement.tagName}:
             return False
         if (
-            self.fullName[0] not in (None, "", "*")
+            self.fullName[0] not in {None, "", "*"}
             and self.fullName[0] != element.domElement.namespaceURI
         ):
             return False
@@ -859,7 +859,7 @@ class CSSBuilder(cssParser.CSSBuilderAbstract):
         return (name, value)
 
     def combineTerms(self, termA, op, termB):
-        if op in (",", " "):
+        if op in {",", " "}:
             if isinstance(termA, list):
                 termA.append(termB)
                 return termA

--- a/xhtml2pdf/w3c/cssDOMElementInterface.py
+++ b/xhtml2pdf/w3c/cssDOMElementInterface.py
@@ -64,9 +64,9 @@ class CSSDOMElementInterface(css.CSSElementInterfaceAbstract):
 
     def matchesNode(self, namespace_tagName):
         namespace, tagName = namespace_tagName
-        if tagName not in ("*", self.domElement.tagName):
+        if tagName not in {"*", self.domElement.tagName}:
             return False
-        if namespace in (None, "", "*"):
+        if namespace in {None, "", "*"}:
             # matches any namespace
             return True
         # full compare

--- a/xhtml2pdf/w3c/cssParser.py
+++ b/xhtml2pdf/w3c/cssParser.py
@@ -439,7 +439,7 @@ class CSSParser:
         Parses CSS file-like objects using the current cssBuilder.
         Use for external stylesheets.
         """
-        with open(srcFile) as file_handler:
+        with open(srcFile, encoding="utf-8") as file_handler:
             file_content = file_handler.read()
 
         return self.parse(file_content)
@@ -707,7 +707,7 @@ class CSSParser:
         while src and src[0] != "{":
             medium, src = self._getIdent(src)
             # make "and ... {" work
-            if medium in (None, "and"):
+            if medium in {None, "and"}:
                 # default to mediatype "all"
                 if medium is None:
                     mediums.append("all")
@@ -924,7 +924,7 @@ class CSSParser:
 
     def _parseSelectorGroup(self, src):
         selectors = []
-        while src[:1] not in ("{", "}", "]", "(", ")", ";", ""):
+        while src[:1] not in {"{", "}", "]", "(", ")", ";", ""}:
             src, selector = self._parseSelector(src)
             if selector is None:
                 break
@@ -941,7 +941,7 @@ class CSSParser:
         """
         src, selector = self._parseSimpleSelector(src)
         srcLen = len(src)  # XXX
-        while src[:1] not in ("", ",", ";", "{", "}", "[", "]", "(", ")"):
+        while src[:1] not in {"", ",", ";", "{", "}", "[", "]", "(", ")"}:
             for combiner in self.SelectorCombiners:
                 if src.startswith(combiner):
                     src = src[len(combiner) :].lstrip()
@@ -954,7 +954,7 @@ class CSSParser:
             if len(src) >= srcLen:
                 src = src[1:]
                 while src and (
-                    src[:1] not in ("", ",", ";", "{", "}", "[", "]", "(", ")")
+                    src[:1] not in {"", ",", ";", "{", "}", "[", "]", "(", ")"}
                 ):
                     src = src[1:]
                 return src.lstrip(), None
@@ -1097,7 +1097,7 @@ class CSSParser:
 
         properties = []
         src = src.lstrip()
-        while src[:1] not in ("", ",", "{", "}", "[", "]", "(", ")", "@"):  # XXX @?
+        while src[:1] not in {"", ",", "{", "}", "[", "]", "(", ")", "@"}:  # XXX @?
             src, single_property = self._parseDeclaration(src)
 
             # XXX Workaround for styles like "*font: smaller"
@@ -1135,7 +1135,7 @@ class CSSParser:
         if property_name is not None:
             src = src.lstrip()
             # S* : S*
-            if src[:1] in (":", "="):
+            if src[:1] in {":", "="}:
                 # Note: we are being fairly flexable here...  technically, the
                 # ":" is *required*, but in the name of flexibility we
                 # suppor a null transition, as well as an "=" transition
@@ -1168,7 +1168,7 @@ class CSSParser:
         """
         src, term = self._parseExpressionTerm(src)
         operator = None
-        while src[:1] not in ("", ";", "{", "}", "[", "]", ")"):
+        while src[:1] not in {"", ";", "{", "}", "[", "]", ")"}:
             for operator in self.ExpressionOperators:
                 if src.startswith(operator):
                     src = src[len(operator) :]

--- a/xhtml2pdf/w3c/cssSpecial.py
+++ b/xhtml2pdf/w3c/cssSpecial.py
@@ -349,7 +349,7 @@ def parseSpecialRules(declarations, debug=0):
                 )
 
         # BORDER TOP, BOTTOM, LEFT, RIGHT
-        elif name in ("border-top", "border-bottom", "border-left", "border-right"):
+        elif name in {"border-top", "border-bottom", "border-left", "border-right"}:
             direction = name[7:]
             width, style, color = splitBorder(parts)
             # print direction, width

--- a/xhtml2pdf/xhtml2pdf_reportlab.py
+++ b/xhtml2pdf/xhtml2pdf_reportlab.py
@@ -421,7 +421,7 @@ class PmlImageReader:  # TODO We need a factory here, returning either a class f
                     self._dataA = PmlImageReader(im.split()[3])
                     im = im.convert("RGB")
                     self.mode = "RGB"
-                elif mode not in ("L", "RGB", "CMYK"):
+                elif mode not in {"L", "RGB", "CMYK"}:
                     im = im.convert("RGB")
                     self.mode = "RGB"
                 self._data = im.tobytes() if hasattr(im, "tobytes") else im.tostring()
@@ -651,8 +651,8 @@ class PmlParagraph(Paragraph, PmlMaxHeightMixIn):
         # self.width = max(1, self.width)
 
         # increase the calculated size by the padding
-        self.width = self.width + self.deltaWidth
-        self.height = self.height + self.deltaHeight
+        self.width += self.deltaWidth
+        self.height += self.deltaHeight
 
         return self.width, self.height
 
@@ -848,7 +848,7 @@ class PmlTable(Table, PmlMaxHeightMixIn):
         if sum(newColWidths) > totalWidth:
             quotient = totalWidth / sum(newColWidths)
             for i in range(len(newColWidths)):
-                newColWidths[i] = newColWidths[i] * quotient
+                newColWidths[i] *= quotient
 
         # To avoid rounding errors adjust one col with the difference
         diff = sum(newColWidths) - totalWidth


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->

What are the [ruff's](https://docs.astral.sh/ruff) fixable [pylint rules](https://docs.astral.sh/ruff/rules/#pylint-pl)?

% `ruff check --select=PL --statistics | grep "\[\*\]" | sort -k 2`
```
  4	PLR1730	[*] if-stmt-min-max
  7	PLR6104	[*] non-augmented-assignment
 65	PLR6201	[*] literal-membership
  1	PLW0108	[*] unnecessary-lambda
  7	PLW1514	[*] unspecified-encoding
```
% `ruff check --select=PL --fix --unsafe-fixes`
```
Found 250 errors (84 fixed, 166 remaining).
```
% `ruff rule PLR6201 ` # Python optimizes `set` membership tests.
# literal-membership (PLR6201)

Derived from the **Pylint** linter.

Fix is always available.

This rule is in preview and is not stable. The `--preview` flag is required for use.

## What it does
Checks for membership tests on `list` and `tuple` literals.

## Why is this bad?
When testing for membership in a static sequence, prefer a `set` literal
over a `list` or `tuple`, as Python optimizes `set` membership tests.

## Example
```python
1 in [1, 2, 3]
```

Use instead:
```python
1 in {1, 2, 3}
```

## Fix safety
This rule's fix is marked as unsafe, as the use of a `set` literal will
error at runtime if the sequence contains unhashable elements (like lists
or dictionaries). While Ruff will attempt to infer the hashability of the
elements, it may not always be able to do so.

## References
- [What’s New In Python 3.2](https://docs.python.org/3/whatsnew/3.2.html#optimizations)