### PR TITLE
pre-commit autoupdate 2024-07-24

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -20,7 +20,7 @@ jobs:
           python-version: "3.12"
       - uses: psf/black@stable
         with:
-          version: "23.9.1"
+          version: "24.4.2"
   ruff:
     runs-on: ubuntu-latest
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.6.0
     hooks:
       - id: check-added-large-files
       - id: check-ast
@@ -36,11 +36,11 @@ repos:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
   - repo: https://github.com/psf/black
-    rev: 23.9.1
+    rev: 24.4.2
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.5.1
+    rev: v1.11.0
     hooks:
     - id: mypy
       additional_dependencies: [types-pkg_resources]

--- a/demo/cherrypy/demo-cherrypy.py
+++ b/demo/cherrypy/demo-cherrypy.py
@@ -45,7 +45,8 @@ class PDFDemo:
     @staticmethod
     def download(data):
         if kid:
-            data = """<?xml version="1.0" encoding="utf-8"?>
+            data = (
+                """<?xml version="1.0" encoding="utf-8"?>
                 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
                   "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
                 <html xmlns="http://www.w3.org/1999/xhtml"
@@ -54,7 +55,9 @@ class PDFDemo:
                     <title>PDF Demo</title>
                   </head>
                   <body>%s</body>
-                </html>""" % data
+                </html>"""
+                % data
+            )
             test = kid.Template(source=data)
             data = test.serialize(output="xhtml")
 

--- a/demo/djangoproject/settings.py
+++ b/demo/djangoproject/settings.py
@@ -9,6 +9,7 @@ https://docs.djangoproject.com/en/1.10/topics/settings/
 For the full list of settings and their values, see
 https://docs.djangoproject.com/en/1.10/ref/settings/
 """
+
 from __future__ import annotations
 
 import os

--- a/demo/djangoproject/test.py
+++ b/demo/djangoproject/test.py
@@ -3,6 +3,7 @@ Created on 22/11/2016
 
 @author: luisza
 """
+
 from django.test import RequestFactory, TestCase
 
 from .utils import extract_request_variables

--- a/demo/djangoproject/urls.py
+++ b/demo/djangoproject/urls.py
@@ -17,6 +17,7 @@ Including another URLconf
     2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
 
 """
+
 from django.conf.urls import url
 
 from . import views

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,6 +12,7 @@ If extensions (or modules to document with autodoc) are in another directory,
 add these directories to sys.path here. If the directory is relative to the
 documentation root, use os.path.abspath to make it absolute, like shown here.
 """
+
 from __future__ import annotations
 
 from build_samples import build_resources

--- a/manual_test/cookbook.py
+++ b/manual_test/cookbook.py
@@ -110,8 +110,7 @@ if __name__ == "__main__":
         "<br>".join(
             [
                 '<p>%s  <span style="color: #f00;"><pdf:pagenumber> of <pdf:pagecount>'
-                " </span></p>"
-                % fake.text()
+                " </span></p>" % fake.text()
                 for x in range(1)
             ]
         )

--- a/manual_test/pdfjoiner.py
+++ b/manual_test/pdfjoiner.py
@@ -17,9 +17,11 @@ from sx.pisa3 import pisa, pisa_pdf
 if __name__ == "__main__":
     pdf = pisa_pdf.pisaPDF()
 
-    subPdf = pisa.pisaDocument("""
+    subPdf = pisa.pisaDocument(
+        """
             Hello <strong>World</strong>
-        """)
+        """
+    )
     pdf.addDocument(subPdf)
 
     with open("test-loremipsum.pdf", "rb") as file:

--- a/manual_test/story2canvas.py
+++ b/manual_test/story2canvas.py
@@ -21,10 +21,13 @@ from xhtml2pdf import pisa
 
 def test(filename):
     # Convert HTML to "Reportlab Story" structure
-    story = pisa.pisaStory("""
+    story = pisa.pisaStory(
+        """
     <h1>Sample</h1>
     <p>Hello <b>World</b>!</p>
-    """ * 20).story
+    """
+        * 20
+    ).story
 
     # Draw to Canvas
     c = Canvas(filename)

--- a/xhtml2pdf/pisa.py
+++ b/xhtml2pdf/pisa.py
@@ -31,7 +31,8 @@ log = logging.getLogger(__name__)
 # Backward compatibility
 CreatePDF = pisaDocument
 
-USAGE = ("""
+USAGE = (
+    """
 
 USAGE: pisa [options] SRC [DEST]
 
@@ -88,7 +89,8 @@ See http.client.HTTPSConnection documentation for this parameters
   --http_cert_file
   --http_source_address
   --http_timeout
-""").strip()
+"""
+).strip()
 
 COPYRIGHT = """
 Copyright 2010 Dirk Holtwick, holtwick.it

--- a/xhtml2pdf/util.py
+++ b/xhtml2pdf/util.py
@@ -78,7 +78,7 @@ class Memoized:
 
 def toList(value: Any, *, cast_tuple: bool = True) -> list:
     cls: tuple[type, ...] = (list, tuple) if cast_tuple else (list,)
-    return list(value) if isinstance(value, cls) else [value]
+    return list(value) if isinstance(value, cls) else [value]  # type: ignore[call-overload]
 
 
 def transform_attrs(obj, keys, container, func, extras=None):

--- a/xhtml2pdf/w3c/cssDOMElementInterface.py
+++ b/xhtml2pdf/w3c/cssDOMElementInterface.py
@@ -35,12 +35,10 @@ class CSSDOMElementInterface(css.CSSElementInterfaceAbstract):
         "not-first-child": lambda self: bool(self.getPreviousSibling()),
         "last-child": lambda self: not bool(self.getNextSibling()),
         "not-last-child": lambda self: bool(self.getNextSibling()),
-        "middle-child": lambda self: not bool(self.getPreviousSibling()) and not bool(
-            self.getNextSibling()
-        ),
-        "not-middle-child": lambda self: bool(self.getPreviousSibling()) or bool(
-            self.getNextSibling()
-        ),
+        "middle-child": lambda self: not bool(self.getPreviousSibling())
+        and not bool(self.getNextSibling()),
+        "not-middle-child": lambda self: bool(self.getPreviousSibling())
+        or bool(self.getNextSibling()),
         # XXX 'first-line':
     }
 


### PR DESCRIPTION
% ` pre-commit install ` # https://pre-commit.com

% ` pre-commit autoupdate`
```
[https://github.com/pre-commit/pre-commit-hooks] updating v4.4.0 -> v4.6.0
[https://github.com/astral-sh/ruff-pre-commit] updating v0.0.292 -> v0.5.4
[https://github.com/psf/black] updating 23.9.1 -> 24.4.2
[https://github.com/pre-commit/mirrors-mypy] updating v1.5.1 -> v1.11.0
```
Revert the `ruff` upgrade for now to keep this pull request easy to review and merge.

% `pre-commit run --all-files`

Most of these modifications are changes for the black 2024 "stable format".

Should we switch from `black` to faster and more compatible `ruff --format`?