### PR TITLE
Fix typos

### DIFF
--- a/docs/source/advanced-usage.rst
+++ b/docs/source/advanced-usage.rst
@@ -29,7 +29,7 @@ the text "To PDF or not to PDF" in the top left of the page:
         )
 
         if pisa_status.err:
-            print("An error occured!")
+            print("An error occurred!")
 
 You can generate files in-memory by writing to a :py:class:`io.StringIO` instance.
 

--- a/docs/source/encryption_and_signatures.rst
+++ b/docs/source/encryption_and_signatures.rst
@@ -32,7 +32,7 @@ The `StandardEncryption` constructor takes the following arguments:
         strength=40):
 
 The userPassword and ownerPassword parameters set the relevant password on the encrypted PDF.
-The boolean flags `canPrint, canModify, canCopy, canAnnotate` determine wether a user can
+The boolean flags `canPrint, canModify, canCopy, canAnnotate` determine whether a user can
 perform the corresponding actions on the PDF when only a user password has been supplied.
 If the user supplies the owner password while opening the PDF, all actions can be performed regardless of the
 flags

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -41,7 +41,7 @@ function.
 
         # Check for errors
         if pisa_status.err:
-            print("An error occured!")
+            print("An error occurred!")
 
 You can generate files in-memory by writing to :py:class:`io.BytesIO` or
 :py:class:`io.StringIO` objects:

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -126,7 +126,7 @@ Position/ floating
 ------------------
 
 Since Reportlab Toolkit does not yet support the use of images within
-paragraphs, images are always rendered in a seperate paragraph.
+paragraphs, images are always rendered in a separate paragraph.
 Therefore floating is not available yet.
 
 Barcodes
@@ -154,7 +154,7 @@ Custom Tags
 ``xhtml2pdf`` provides some custom tags. They are all prefixed by the
 namespace identifier ``pdf:``. As the HTML5 parser used by xhtml2pdf
 does not know about these specific tags it may be confused if they are
-without a block. To avoid problems you may condsider sourrounding them
+without a block. To avoid problems you may condsider surrounding them
 by ``<div>`` tags, like this:
 
 ::

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -326,7 +326,7 @@ Released: 2020-10-08
 * Fixed support for multiple fonts and unicode :issue:`492`
 * Fixed an encoding issue with html5lib :issue:`468`
 * Fixed a problem with the ``border`` property in ``h1`` to ``h6`` heading tags :issue:`466` :issue:`495`
-* Fixed compability with ReportLab 3.5.X :issue:`404` :issue:`463`
+* Fixed compatibility with ReportLab 3.5.X :issue:`404` :issue:`463`
 * Removed default background-image when no background-image is defined :issue:`484`
 * Fixed an issue with different font type that have the same name :issue:`381`
 * Fixed a bug that prevented support for Python 3.X :issue:`513`
@@ -696,7 +696,7 @@ Version 3.0.29, 2008-12-01
 
 - NEW: Warning if Reportlab 2.2 is not installed
 - UPD: Better support for named colors
-- UPD: Modifed frame handling to better support relative values
+- UPD: Modified frame handling to better support relative values
 - FIX: Splitting paragraph threw errors some times; also had problems with line breaks on the second page, fix for RL 2.2 paragraph was needed
 - FIX: Added margins to <blockquote> default CSS
 - FIX: Inline images in static frames did not work
@@ -715,7 +715,7 @@ Version 3.0.28, 2008-11-21
 - NEW: PDF Joiner to concatenate many PDF and pisa documents
 - NEW: Page backgrounds can now be images or PDF
 - NEW: Visual Unittests based on ImageMagick and TortoiseIDiff (for Windows)
-- NEW: Pisa raises execptions now if errors occure; with pisaDocument(..., raise_execeptions=False) you can turn them off
+- NEW: Pisa now raises exceptions if errors occurred; with pisaDocument(..., raise_exception=False) you can turn them off
 - UPD: Paragraphs now use the maximum leading to avoid overlapping text
 - UPD: Removed "Keep with next" from H1 to H6
 - FIX: Sizing of images is now handled better; should better work with PIL
@@ -726,7 +726,7 @@ Version 3.0.28, 2008-11-21
 - FIX: Single <br> between two blocks now creates a new line
 - FIX: Set table attribute "repeat" to "0"
 - FIX: Some <font> attributes did not work as expected
-- FIX: Font sizes reworked to behave like browser implmentations
+- FIX: Font sizes reworked to behave like browser implementations
 - FIX: Like in most HTML browser table cells now have "valign=middle" and table headers have font weight bold
 - FIX: Little fix in CSS parsing
 - FIX: Default of <link media=""> was "screen", changed to "all"
@@ -735,7 +735,7 @@ Version 3.0.28, 2008-11-21
 Version 3.0.27, 2008-10-04
 
 - INF: License changed from Qt to GPLv2
-- INF: Not yet completely combatible with Reportlab 2.2 (&nbsp; errors and borders)
+- INF: Not yet completely compatible with Reportlab 2.2 (&nbsp; errors and borders)
 - NEW: Command line tool called "xhtml" ("pisa" still available but will be deprecated with pisa 3.1)
 - NEW: EGG for Python 2.6
 - NEW: Basic support for Data URI
@@ -873,8 +873,8 @@ Version 3.0.13, 2008-01-22
 - Added a demo using cherrypy web server and kid
 - Added a demo using django framework
 - Modified test-background.html to work with CSS
-- Added suport for bold and italic TTF fonts to the @font-face CSS section (Robert Klep)
-- Added suport for bold and italic Postscript fonts to the @font-face CSS section
+- Added support for bold and italic TTF fonts to the @font-face CSS section (Robert Klep)
+- Added support for bold and italic Postscript fonts to the @font-face CSS section
 - The @-rules are not need a trailing space after ident any more (Robert Klep)
 - Fixed the Windows standalone version to work
 - Made the 'sx' folder more sharable by modifying __init__.py

--- a/manual_test/linkloading.py
+++ b/manual_test/linkloading.py
@@ -44,7 +44,7 @@ def dummyLoader(_name):
 
 class myLinkLoader:
     """
-    This object is just a wrapper to track additional informations
+    This object is just a wrapper to track additional information
     and handle temporary files after they are not needed any more.
     """
 

--- a/manual_test/simple.py
+++ b/manual_test/simple.py
@@ -28,9 +28,9 @@ def dumpErrors(pdf, *, _showLog=True):
     #    for mode, line, msg, code in pdf.log:
     #        print "%s in line %d: %s" % (mode, line, msg)
     # if pdf.warn:
-    #    print "*** %d WARNINGS OCCURED" % pdf.warn
+    #    print "*** %d WARNINGS OCCURRED" % pdf.warn
     if pdf.err:
-        print(f"*** {pdf.err} ERRORS OCCURED")
+        print(f"*** {pdf.err} ERRORS OCCURRED")
 
 
 def testSimple(

--- a/manual_test/test-bidirectional-text.html
+++ b/manual_test/test-bidirectional-text.html
@@ -36,7 +36,7 @@ html, * {
     font-family: freefont !important;
 }
 img {
-    font-familiy: Helvetica !important;
+    font-family: Helvetica !important;
 }
 </style>
 </head>
@@ -47,7 +47,7 @@ img {
 <h1 lang="en">Bidirectional&nbsp;text &#183; <span>Bidirectional&nbsp;text</span></h1>
 
 <p lang="en">This page contains some accompanying examples to Alan Flavell&#8217;s &#8220;<a href="flavell/text-direction.html">I18n &#8211; text direction</a>&#8221;. Examples that are supposed to display <span class="fail">incorrectly</span> (i.e. not as intended) in either Mozilla or Internet Explorer&nbsp;6 are <span class="fail">in red</span>. Read the source text to understand how it&#8217;s done!</p>
-<img src="http://www.w3.org/Icons/valid-html401.gif" style="font-familiy: Helvetica">
+<img src="http://www.w3.org/Icons/valid-html401.gif" style="font-family: Helvetica">
 
 <p lang="en">You can specify text direction by (paired) Unicode control characters, by (paired) control characters written as numeric references, by HTML markup, or by CSS properties. Control characters are restricted to plain text and are <a href="http://www.w3.org/TR/unicode-xml/#Suitable"><em>not</em> suitable for use with markup languages</a> (except <a href="http://www.w3.org/TR/unicode-xml/#Format"><code>lrm</code> and <code>rlm</code></a>). The preferred method for HTML is to use HTML markup. Use control characters written as numeric references only in places where no markup is possible, such as attribute values (<code>alt</code>, <code>title</code>, etc.). Occasionally it may be convenient to specify <a href="http://www.w3.org/TR/REC-CSS2/visuren.html#direction">text direction via CSS</a>; for example, to set the <a href="table8.css.text">direction of columns in tables</a> rather than to put a <code>dir</code> attribute into each and every <code>&lt;td></code>.</p>
 

--- a/manual_test/test-pisa-toc.html
+++ b/manual_test/test-pisa-toc.html
@@ -46,7 +46,7 @@ when using mouse-intensive graphical applications every day.
   <br> <strong>Homepage:</strong> <a href="http://www.blender.org/">http://www.blender.org</a>
   <br> <strong>Software version used for this installation:</strong> Blender 2.43
   <br> <strong>Operating System used for thisinstalltion:</strong> OSX (10.4.8)
-  <br> <strong>Reccomended Hardware:</strong> Powerbook G4, Powermac G5, Mac Pro, MacBookPro, iMac (core Duo)
+  <br> <strong>Recommended Hardware:</strong> Powerbook G4, Powermac G5, Mac Pro, MacBookPro, iMac (core Duo)
 </p>
 <h2> Downloading
 </h2>

--- a/tests/test_asian_font_support.py
+++ b/tests/test_asian_font_support.py
@@ -17,7 +17,7 @@ class AsianFontSupportTests(TestCase):
     Adobe asian language pack in Report Lab:
 
     Simplified Chinese = ['STSong-Light']
-    Tradicional Chinese = ['MSung-Light']
+    Traditional Chinese = ['MSung-Light']
     Japanese = ['HeiseiMin-W3', 'HeiseiKakuGo-W5']
     Korean = ['HYSMyeongJo-Medium','HYGothic-Medium']
     """
@@ -104,9 +104,9 @@ class AsianFontSupportTests(TestCase):
     def test_asian_font_in_pdf(self):
         """
         Tests if the asian fonts used in the CSS property "font-family"
-        are correctly embeded in the pdf result.
+        are correctly embedded in the pdf result.
         """
-        # Read the embeded fonts from the finished pdf file
+        # Read the embedded fonts from the finished pdf file
         with io.BytesIO() as pdf_file:
             pisa_doc = pisaDocument(src=self.HTML_CONTENT, dest=pdf_file)
             pdf_file.seek(0)

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -96,10 +96,10 @@ class DocumentTest(TestCase):
             objects = [xobjects[key] for key in xobjects]
 
             # Identity the 'denker_transparent.png' image by its height and width, and make sure it's there.
-            denker_transparant = [
+            denker_transparent = [
                 obj for obj in objects if obj["/Height"] == 137 and obj["/Width"] == 70
             ]
-            self.assertEqual(len(denker_transparant), 1)
+            self.assertEqual(len(denker_transparent), 1)
 
     def test_document_background_image(self) -> None:
         """Test that a transparent PNG image is rendered properly."""
@@ -125,10 +125,10 @@ class DocumentTest(TestCase):
             objects = [xobjects[key] for key in xobjects]
 
             # Identity the 'denker_transparent.png' image by its height and width, and make sure it's there.
-            denker_transparant = [
+            denker_transparent = [
                 obj for obj in objects if obj["/Height"] == 137 and obj["/Width"] == 70
             ]
-            self.assertEqual(len(denker_transparant), 1)
+            self.assertEqual(len(denker_transparent), 1)
 
     def test_document_background_image_not_on_all_pages(self) -> None:
         """Test that all pages are being rendered, when background is a pdf file and it's applied for the first page only."""

--- a/tests/test_right_to_left_font_support.py
+++ b/tests/test_right_to_left_font_support.py
@@ -99,7 +99,7 @@ class RightToLeftFontSupportTests(TestCase):
     def test_pdf_language_tag_in_html(self) -> None:
         """
         this function is used to check if the "Custom Tag" <pdf:language/>
-        is located in the HTML file through asssertNotEqual()
+        is located in the HTML file through assertNotEqual()
         """
         text = ""
         language_tag = '<pdf:language name=""/>'

--- a/xhtml2pdf/document.py
+++ b/xhtml2pdf/document.py
@@ -35,14 +35,14 @@ log = logging.getLogger(__name__)
 def pisaErrorDocument(dest, c):
     out = pisaTempFile(capacity=c.capacity)
     out.write(
-        "<p style='background-color:red;'><strong>%d error(s) occured:</strong><p>"
+        "<p style='background-color:red;'><strong>%d error(s) occurred:</strong><p>"
         % c.err
     )
     for mode, line, msg, _ in c.log:
         if mode == "error":
             out.write("<pre>%s in line %d: %s</pre>" % (mode, line, html_escape(msg)))
 
-    out.write("<p><strong>%d warning(s) occured:</strong><p>" % c.warn)
+    out.write("<p><strong>%d warning(s) occurred:</strong><p>" % c.warn)
     for mode, line, msg, _ in c.log:
         if mode == "warning":
             out.write("<p>%s in line %d: %s</p>" % (mode, line, html_escape(msg)))

--- a/xhtml2pdf/files.py
+++ b/xhtml2pdf/files.py
@@ -74,7 +74,7 @@ class pisaTempFile:
         try:
             self._delegate = self.STRATEGIES[self.strategy]()
         except IndexError:
-            # Fallback for Google AppEnginge etc.
+            # Fallback for Google AppEngine etc.
             self._delegate = self.STRATEGIES[0]()
         self.write(buffer)
         # we must set the file's position for preparing to read
@@ -208,7 +208,7 @@ class B64InlineURI(BaseFile):
             or "base64," not in self.path
             or len(parts) != 2
         ):
-            msg = "Base64-encoded data URI is mailformed"
+            msg = "Base64-encoded data URI is malformed"
             raise RuntimeError(msg)
         data = parts[1]
         # Strip 'data:' prefix and split mime type with optional params

--- a/xhtml2pdf/paragraph.py
+++ b/xhtml2pdf/paragraph.py
@@ -538,7 +538,7 @@ class Paragraph(Flowable):
 
         canvas.saveState()
 
-        # Draw box arround paragraph for debugging
+        # Draw box around paragraph for debugging
         if self.debug:
             bw: float = 0.5
             bc: Color = Color(1, 1, 0)

--- a/xhtml2pdf/parser.py
+++ b/xhtml2pdf/parser.py
@@ -776,7 +776,7 @@ def pisaParser(
 ):
     """
     - Parse HTML and get miniDOM
-    - Extract CSS informations, add default CSS, parse CSS
+    - Extract CSS information, add default CSS, parse CSS
     - Handle the document DOM itself and build reportlab story
     - Return Context object.
     """

--- a/xhtml2pdf/pisa.py
+++ b/xhtml2pdf/pisa.py
@@ -57,7 +57,7 @@ DEST
   --css-dump:
     Dumps the default CSS definitions to STDOUT
   --debug, -d:
-    Show debugging informations
+    Show debugging information
   --encoding:
     the character encoding of SRC. If left empty (default) this
     information will be extracted from the HTML header data
@@ -227,7 +227,7 @@ def execute():
         elif o in {"--system"}:
             print(COPYRIGHT)
             print()
-            print("SYSTEM INFORMATIONS")
+            print("SYSTEM INFORMATION")
             print("--------------------------------------------")
             print("OS:                %s" % sys.platform)
             print("Python:            %s" % sys.version)
@@ -419,7 +419,7 @@ def showLogging(*, debug=False):
         logging.basicConfig()
 
 
-# Background informations in data URI here:
+# Background information in data URI here:
 # http://en.wikipedia.org/wiki/Data_URI_scheme
 
 

--- a/xhtml2pdf/reportlab_paragraph.py
+++ b/xhtml2pdf/reportlab_paragraph.py
@@ -727,7 +727,7 @@ def _do_post_text(tx):
     """
     Try to find out what the variables mean:
 
-    tx         A structure containing more informations about paragraph ???
+    tx         A structure containing more information about paragraph ???
 
     leading    Height of lines
     ff         1/8 of the font size

--- a/xhtml2pdf/tables.py
+++ b/xhtml2pdf/tables.py
@@ -343,7 +343,7 @@ class pisaTagTD(pisaTag):
         # Get value of with, if no spanning
         if not cspan:
             width = c.frag.width or self.attr.width
-            # If is value, the set it in the right place in the arry
+            # If is value, the set it in the right place in the array
             if width is not None:
                 tdata.colw[col] = _width(width)
                 log.debug("Col %d has width %s", col, width)

--- a/xhtml2pdf/tags.py
+++ b/xhtml2pdf/tags.py
@@ -575,10 +575,10 @@ class pisaTagPDFPAGENUMBER(pisaTag):
 
     def start(self, c: pisaContext) -> None:  # noqa: PLR6301
         flow = PageNumberFlowable()
-        pn = c.addPageNumber(flow)
+        pageNumber = c.addPageNumber(flow)
         c.addStory(flow)
         c.frag.pageNumber = True
-        c.addFrag(pn)
+        c.addFrag(pageNumber)
         c.frag.pageNumber = False
 
 
@@ -587,10 +587,10 @@ class pisaTagPDFPAGECOUNT(pisaTag):
 
     def start(self, c: pisaContext) -> None:  # noqa: PLR6301
         flow = PageNumberFlowable()
-        pc = c.getPageCount(flow)
+        pageCount = c.getPageCount(flow)
         c.addStory(flow)
         c.frag.pageCount = True
-        c.addFrag(pc)
+        c.addFrag(pageCount)
         c.frag.pageCount = False
 
     def end(self, c: pisaContext) -> None:  # noqa: PLR6301

--- a/xhtml2pdf/tags.py
+++ b/xhtml2pdf/tags.py
@@ -78,7 +78,7 @@ class pisaTag:
 
 class pisaTagBODY(pisaTag):
     """
-    We can also asume that there is a BODY tag because html5lib
+    We can also assume that there is a BODY tag because html5lib
     adds it for us. Here we take the base font size for later calculations
     in the FONT tag.
     """

--- a/xhtml2pdf/util.py
+++ b/xhtml2pdf/util.py
@@ -49,7 +49,7 @@ class Memoized:
     Don't pass in too large kwargs, since this turns them into a tuple of
     tuples. Also, avoid mutable types (as usual for memoizers)
 
-    What this does is to create a dictionnary of {(*parameters):return value},
+    What this does is to create a dictionary of {(*parameters):return value},
     and uses it as a cache for subsequent calls to the same method.
     It is especially useful for functions that don't rely on external variables
     and that are called often. It's a perfect match for our getSize etc...
@@ -83,8 +83,8 @@ def toList(value: Any, *, cast_tuple: bool = True) -> list:
 
 def transform_attrs(obj, keys, container, func, extras=None):
     """
-    Allows to apply one function to set of keys cheching if key is in container,
-    also trasform ccs key to report lab keys.
+    Allows to apply one function to set of keys checking if key is in container,
+    also transform ccs key to report lab keys.
 
     extras = Are extra params for func, it will be call like func(*[param1, param2])
 

--- a/xhtml2pdf/w3c/css.py
+++ b/xhtml2pdf/w3c/css.py
@@ -172,7 +172,7 @@ class CSSCascadeStrategy:
 
         inline = element.getInlineStyle()
 
-        # Generator are wonderfull but sometime slow...
+        # Generator are wonderful but sometime slow...
         # for ruleset in self.iterCSSRulesets(inline):
         #    rules += ruleset.findCSSRuleFor(element, attrName)
 
@@ -215,7 +215,7 @@ class CSSCascadeStrategy:
     def _extractStyleForRule(rule, attrName, default=NotImplemented):
         if rule:
             # rule is packed in a list to differentiate from "no rule" vs "rule
-            # whose value evalutates as False"
+            # whose value evaluates as False"
             style = rule[-1][1]
             return style[attrName]
         if default is not NotImplemented:
@@ -639,7 +639,7 @@ class CSSRuleset(dict):
 
     def findCSSRuleFor(self, element, attrName):
         # rule is packed in a list to differentiate from "no rule" vs "rule
-        # whose value evalutates as False"
+        # whose value evaluates as False"
         return self.findCSSRulesFor(element, attrName)[-1:]
 
     def mergeStyles(self, styles):
@@ -660,7 +660,7 @@ class CSSInlineRuleset(CSSRuleset, CSSDeclarations):
 
     def findCSSRuleFor(self, *args, **kw):
         # rule is packed in a list to differentiate from "no rule" vs "rule
-        # whose value evalutates as False"
+        # whose value evaluates as False"
         return self.findCSSRulesFor(*args, **kw)[-1:]
 
 

--- a/xhtml2pdf/w3c/cssParser.py
+++ b/xhtml2pdf/w3c/cssParser.py
@@ -14,7 +14,7 @@ The CSS 2.1 Specification this parser was derived from can be found at http://ww
 Primary Classes:
     * CSSParser
         Parses CSS source forms into results using a Builder Pattern.  Must
-        provide concrete implemenation of CSSBuilderAbstract.
+        provide concrete implementation of CSSBuilderAbstract.
 
     * CSSBuilderAbstract
         Outlines the interface between CSSParser and it's rule-builder.
@@ -389,7 +389,7 @@ class CSSParser:
     # XXX For now
     # i_uri = '(url\\(.*?\\))'
     re_uri = re.compile(i_uri, _reflags)
-    i_num = (  # XXX Added out paranthesis, because e.g. .5em was not parsed correctly
+    i_num = (  # XXX Added out parenthesis, because e.g. .5em was not parsed correctly
         r"(([-+]?[0-9]+(?:\.[0-9]+)?)|([-+]?\.[0-9]+))"
     )
     re_num = re.compile(i_num, _reflags)
@@ -466,7 +466,7 @@ class CSSParser:
     def parseInline(self, src):
         """
         Parses CSS inline source string using the current cssBuilder.
-        Use to parse a tag's 'sytle'-like attribute.
+        Use to parse a tag's 'style'-like attribute.
         """
         self.cssBuilder.beginInline()
         try:
@@ -950,7 +950,7 @@ class CSSParser:
                 combiner = " "
             src, selectorB = self._parseSimpleSelector(src)
 
-            # XXX Fix a bug that occured here e.g. : .1 {...}
+            # XXX Fix a bug that occurred here e.g. : .1 {...}
             if len(src) >= srcLen:
                 src = src[1:]
                 while src and (
@@ -1136,9 +1136,9 @@ class CSSParser:
             src = src.lstrip()
             # S* : S*
             if src[:1] in {":", "="}:
-                # Note: we are being fairly flexable here...  technically, the
+                # Note: we are being fairly flexible here...  technically, the
                 # ":" is *required*, but in the name of flexibility we
-                # suppor a null transition, as well as an "=" transition
+                # support a null transition, as well as an "=" transition
                 src = src[1:].lstrip()
 
             src, single_property = self._parseDeclarationProperty(src, property_name)

--- a/xhtml2pdf/w3c/cssSpecial.py
+++ b/xhtml2pdf/w3c/cssSpecial.py
@@ -1,5 +1,5 @@
 """
-Helper for complex CSS definitons like font, margin, padding and border
+Helper for complex CSS definitions like font, margin, padding and border
 Optimized for use with PISA.
 
 Copyright 2010 Dirk Holtwick, holtwick.it
@@ -59,7 +59,7 @@ _weightTable = {
 #    "x-large": 3./2.,
 #    "xx-large": 2./1.,
 #    "xxx-large": 3./1.,
-#    "larger": 1.25,      # XXX Not totaly CSS conform:
+#    "larger": 1.25,      # XXX Not totally CSS conform:
 #    "smaller": 0.75,     # http://www.w3.org/TR/CSS21/fonts.html#propdef-font-size
 #    }
 
@@ -159,7 +159,7 @@ def parseSpecialRules(declarations, debug=0):
         elif name == "background":
             # [<'background-color'> || <'background-image'> || <'background-repeat'> || <'background-attachment'> || <'background-position'>] | inherit
 
-            # XXX We do not receive url() and parts list, so we go for a dirty work arround
+            # XXX We do not receive url() and parts list, so we go for a dirty work around
             part = getNextPart(parts) or oparts
             if part:
                 if isinstance(part, str) and (("." in part) or ("data:" in part)):

--- a/xhtml2pdf/xhtml2pdf_reportlab.py
+++ b/xhtml2pdf/xhtml2pdf_reportlab.py
@@ -302,7 +302,7 @@ class PmlImageReader:  # TODO We need a factory here, returning either a class f
         if isinstance(fileName, PmlImage):
             self.__dict__ = fileName.__dict__  # borgize
             return
-            # start wih lots of null private fields, to be populated by
+            # start with lots of null private fields, to be populated by
         # the relevant engine.
         self.fileName: PmlImage | Image | str = fileName or f"PILIMAGE_{id(self)}"
         self._image: Image = None
@@ -520,7 +520,7 @@ class PmlImage(Flowable, PmlMaxHeightMixIn):
         factor = min(wfactor, hfactor)
         self.dWidth = self.drawWidth * factor
         self.dHeight = self.drawHeight * factor
-        # print "imgage result", factor, self.dWidth, self.dHeight
+        # print "image result", factor, self.dWidth, self.dHeight
         return self.dWidth, self.dHeight
 
     def getDrawing(
@@ -641,7 +641,7 @@ class PmlParagraph(Paragraph, PmlMaxHeightMixIn):
         availWidth -= self.deltaWidth
         availHeight -= self.deltaHeight
 
-        # Modify maxium image sizes
+        # Modify maximum image sizes
         self._calcImageMaxSizes(availWidth, availHeight)
 
         # call the base class to do wrapping and calculate the size


### PR DESCRIPTION
### Short description
This PR includes typo fixes found in this project

### Proposed changes
Most are simple documentation corrections however there are a couple of user facing changes:

- `pisaErrorDocument()` corrects a typo of `occured` -> `occurred` in its output
- `pisaLinkLoader --system` command outputs `SYSTEM INFORMATIONS` -> `SYSTEM INFORMATION`

These are both minor changes but I guess someone could be parsing the output of them.
