### PR TITLE
Fix TypeError

### DIFF
--- a/xhtml2pdf/reportlab_paragraph.py
+++ b/xhtml2pdf/reportlab_paragraph.py
@@ -1781,7 +1781,7 @@ class Paragraph(Flowable):
         """
         frags = getattr(self, "frags", None)
         if frags:
-            return "".join([frag.text] for frag in frags if hasattr(frag, "text"))
+            return "".join(frag.text for frag in frags if hasattr(frag, "text"))
         if identify:
             text = getattr(self, "text", None)
             if text is None:


### PR DESCRIPTION
### Short description

Fix an exception due to invalid python code:

```
  File "pdf/documents.py", line 59, in _write_single_page_content
    pisa_status = pisa.CreatePDF(
  File "xhtml2pdf/document.py", line 196, in pisaDocument
    doc.build(context.story)
  File "reportlab/platypus/doctemplate.py", line 1083, in build
    self.handle_flowable(flowables)
  File "reportlab/platypus/doctemplate.py", line 959, in handle_flowable
    (self._fIdent(f,60,frame),_fSizeString(f),self.page, self.frame.id,
  File "reportlab/platypus/doctemplate.py", line 894, in _fIdent
    return f.identity(maxLen)
  File "reportlab/platypus/flowables.py", line 183, in identity
    r = self.getPlainText(identify=1)
  File "xhtml2pdf/reportlab_paragraph.py", line 1792, in getPlainText
    return "".join([frag.text] for frag in frags if hasattr(frag, "text"))
TypeError: sequence item 0: expected str instance, list found
```