### PR TITLE
Fix typos

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -18,7 +18,7 @@ Contributors
 ============
 
 In no particular order. Names are taken from git logs, please contact
-the maintainer should theses names be changed to something more relevant.
+the maintainer should these names be changed to something more relevant.
 
 * Kenji Noguschi
 * Pascal Bach

--- a/xhtml2pdf/w3c/cssParser.py
+++ b/xhtml2pdf/w3c/cssParser.py
@@ -892,7 +892,7 @@ class CSSParser:
                 # consume the rest of the content since we didn't find a block or a semicolon
                 src = src[-1:-1]
             elif blockIdx is not None:
-                # expecing a block...
+                # expecting a block...
                 src = src[blockIdx:]
                 try:
                     # try to parse it as a declarations block


### PR DESCRIPTION
### Short description

Fix typos found via `codespell -S
./tests,testrender,manual_test,reportlab_paragraph.py -L splitted`


### Proposed changes

None

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #
