### PR TITLE
Ignore http status reason text

### DIFF
--- a/xhtml2pdf/files.py
+++ b/xhtml2pdf/files.py
@@ -269,7 +269,7 @@ class NetworkFileUri(BaseFile):
             conn = httplib.HTTPConnection(server)
         conn.request("GET", path)
         r1: HTTPResponse = conn.getresponse()
-        if (r1.status, r1.reason) == (200, "OK"):
+        if r1.status == 200:
             self.mimetype = r1.getheader("Content-Type", "").split(";")[0]
             data = r1.read()
             if r1.getheader("content-encoding") == "gzip":


### PR DESCRIPTION
The reason text is not required and should be ignored. Encountered errors against server using Apache -> AJP -> Tomcat. 

Running xhtml2pdf in debug mode I noticed: 'Received non-200 status: 200 200', while trying to fetch remote resources. 
Tomcats (newer than 8.5) behind AJP connector respond with "HTTP/1.1 200 200" which breaks reason "OK" check. 
Previous versions respond with "HTTP/1.1 200 OK"

https://www.rfc-editor.org/rfc/rfc7230
"The reason-phrase element exists for the sole purpose of providing a textual description associated with the numeric status code, mostly out of deference to earlier Internet application protocols that were more frequently used with interactive text clients. A client SHOULD ignore the reason-phrase content."