### PR TITLE
Several fixes to background processing

### DIFF
--- a/xhtml2pdf/context.py
+++ b/xhtml2pdf/context.py
@@ -473,7 +473,6 @@ class pisaCSSBuilder(css.CSSBuilder):
         pt = PmlPageTemplate(id=name, frames=frameList, pagesize=c.pageSize)
         pt.pisaStaticList = staticList
         pt.pisaBackground = background
-        pt.pisaBackgroundList = c.pisaBackgroundList
         pt.backgroundContext = background_context
 
         if isLandscape:
@@ -592,7 +591,6 @@ class pisaContext:
         self.frameStatioundList: list = []
         self.log: list = []
         self.path: list = []
-        self.pisaBackgroundList: list = []
         self.select_options: list[str] = []
         self.story: list = []
         self.image: PmlImage | None = None

--- a/xhtml2pdf/document.py
+++ b/xhtml2pdf/document.py
@@ -197,7 +197,7 @@ def pisaDocument(
 
     # Add watermarks
     output = io.BytesIO()
-    output, has_bg = WaterMarks.process_doc(context, out, output)
+    output, has_bg = WaterMarks.process_doc(doc, out, output)
 
     if not has_bg:
         output = out

--- a/xhtml2pdf/tags.py
+++ b/xhtml2pdf/tags.py
@@ -670,7 +670,6 @@ class pisaTagPDFTEMPLATE(pisaTag):
 
         pt = PmlPageTemplate(id=name, frames=c.frameList, pagesize=A4)
         pt.pisaStaticList = c.frameStaticList
-        pt.pisaBackgroundList = c.pisaBackgroundList
         pt.pisaBackground = self.attr.background
 
         c.templateList[name] = pt


### PR DESCRIPTION
The existing background processing had a few flaws.

- a template without a background, or with a non-existing background image would retain the background from an earlier template
- if a template was used multiple times, the background would only be switched the first time the template was used.
- if the document was build multiple times (for instance, due to multi-page TOC), the pages where the background was used was based on the first render, not the final render, causing an off-by-many in positioning the background images.

Fixes #820, #822, #823.