### PR TITLE
Set /Lang in PDF catalog from HTML lang attribute

### DIFF
--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -347,3 +347,39 @@ class DocumentTest(TestCase):
                 dest=in_memory_file,
             )
             self.assertGreater(len(in_memory_file.getvalue()), 0)
+
+    def test_lang_from_html_attribute(self) -> None:
+        """Test that the lang attribute on <html> is written to the PDF catalog."""
+        html = '<!DOCTYPE html><html lang="es"><body><p>Hola</p></body></html>'
+        with io.BytesIO() as pdf_file:
+            pisaDocument(src=io.StringIO(html), dest=pdf_file)
+            pdf_file.seek(0)
+            reader = PdfReader(pdf_file)
+            root = reader.trailer["/Root"]
+            self.assertEqual(root.get("/Lang"), "es")
+
+    def test_lang_from_pdf_language_tag(self) -> None:
+        """Test that <pdf:language name="..."/> sets /Lang in the PDF catalog."""
+        html = (
+            "<!DOCTYPE html><html><body>"
+            '<pdf:language name="fr"/>'
+            "<p>Bonjour</p></body></html>"
+        )
+        with io.BytesIO() as pdf_file:
+            pisaDocument(src=io.StringIO(html), dest=pdf_file)
+            pdf_file.seek(0)
+            reader = PdfReader(pdf_file)
+            root = reader.trailer["/Root"]
+            self.assertEqual(root.get("/Lang"), "fr")
+
+    def test_no_lang_when_omitted(self) -> None:
+        """Test that /Lang is absent when no language is specified."""
+        with io.BytesIO() as pdf_file:
+            pisaDocument(
+                src=io.StringIO(HTML_CONTENT.format(head="", extra_html="")),
+                dest=pdf_file,
+            )
+            pdf_file.seek(0)
+            reader = PdfReader(pdf_file)
+            root = reader.trailer["/Root"]
+            self.assertNotIn("/Lang", root)

--- a/xhtml2pdf/default.py
+++ b/xhtml2pdf/default.py
@@ -376,6 +376,7 @@ TAGS = {
         {"align": ["left", "center", "right", "justify"], "dir": ["ltr", "rtl"]},
     ),
     "p": (1, {"align": ["left", "center", "right", "justify"], "dir": ["ltr", "rtl"]}),
+    "html": (0, {"lang": (STRING, "")}),
     "body": (1, {"dir": ["ltr", "rtl"]}),
     "br": (0, {}),
     "h1": (

--- a/xhtml2pdf/document.py
+++ b/xhtml2pdf/document.py
@@ -161,6 +161,7 @@ def pisaDocument(
         showBoundary=0,
         encrypt=get_encrypt_instance(encrypt),
         allowSplitting=1,
+        lang=context.language or None,
     )
 
     # Prepare templates and their frames

--- a/xhtml2pdf/parser.py
+++ b/xhtml2pdf/parser.py
@@ -63,6 +63,7 @@ from xhtml2pdf.tags import (  # noqa: F401
     pisaTagH5,
     pisaTagH6,
     pisaTagHR,
+    pisaTagHTML,
     pisaTagIMG,
     pisaTagINPUT,
     pisaTagLI,

--- a/xhtml2pdf/tags.py
+++ b/xhtml2pdf/tags.py
@@ -76,6 +76,14 @@ class pisaTag:
         pass
 
 
+class pisaTagHTML(pisaTag):
+    """Extract the lang attribute from the <html> tag."""
+
+    def start(self, c: pisaContext) -> None:
+        if self.attr.lang:
+            c.language = self.attr.lang
+
+
 class pisaTagBODY(pisaTag):
     """
     We can also assume that there is a BODY tag because html5lib


### PR DESCRIPTION
### Short description

I noticed that the `lang` attribute on `<html>` and the `<pdf:language>` tag were parsed
into `context.language` but never actually written to the PDF. This adds the missing `/Lang`
entry to the catalog.

### Proposed changes

- Register the `<html>` tag in the attribute parser so `lang` gets extracted
- Add `pisaTagHTML` to store the language in the pisa context
- Pass `context.language` to reportlab's `BaseDocTemplate` (it already supports `/Lang`)
- Add tests for `<html lang="...">`, `<pdf:language name="..."/>`, and the no-lang case

### Resolved issues

Fixes: #750