### PR TITLE
Handle percentage values in getSize when relative is zero

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -140,6 +140,16 @@ class UtilsGetSizeTestCase(TestCase):
         res = getSize("auto")  # Really?
         self.assertEqual(res, 0.0)
 
+    def test_get_size_for_percentage_without_relative(self):
+        res = getSize("100%")
+        self.assertEqual(res, 0.0)
+
+    def test_get_size_for_percentage_with_relative(self):
+        res = getSize("100%", 200)
+        self.assertEqual(res, 200.0)
+        res = getSize("50%", 200)
+        self.assertEqual(res, 100.0)
+
 
 class PisaDimensionTestCase(TestCase):
     def test_frame_dimensions_left_top_width_height(self):

--- a/xhtml2pdf/util.py
+++ b/xhtml2pdf/util.py
@@ -248,6 +248,8 @@ def getSize(
             return float(value[:-2].strip()) * DPI96
         if value in {"none", "0", "0.0", "auto"}:
             return 0.0
+        if value.endswith("%"):
+            return (relative * float(value[:-1].strip())) / 100.0
         if relative:
             if value.endswith("rem"):  # XXX
                 # 1rem = 1 * fontSize
@@ -258,9 +260,6 @@ def getSize(
             if value.endswith("ex"):  # XXX
                 # 1ex = 1/2 fontSize
                 return float(value[:-2].strip()) * (relative / 2.0)
-            if value.endswith("%"):
-                # 1% = (fontSize * 1) / 100
-                return (relative * float(value[:-1].strip())) / 100.0
             if value in {"normal", "inherit"}:
                 return relative
             if value in RELATIVE_SIZE_TABLE:


### PR DESCRIPTION
### Short description

Moves the percentage check in `getSize` before the `if relative:` guard so that values like `"100%"` are handled correctly even when no relative base is provided.

### Proposed changes

When `getSize` received a percentage value (e.g. `"100%"`) with `relative=0` (the default), the `if relative:` block was skipped entirely. The code then fell through to `float("100%")`, which failed and logged the confusing warning `getSize: Not a float '100%'`.

I moved the `value.endswith("%")` check before the `if relative:` block. When `relative` is zero, the calculation `(0 * 100) / 100.0` correctly returns `0.0` without emitting a spurious warning. When `relative` is non-zero, the behavior is unchanged.

### Resolved issues

Fixes: #411