### PR TITLE
Support dashed and dotted border styles

### DIFF
--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -152,7 +152,8 @@ class TableDataTestCase(TestCase):
         instance = self.sut()
         instance.add_cell_styles(context, (0, 1), (3, 5), mode="tr")
         self.assertEqual(
-            instance.styles[0], ("LINEABOVE", (0, 1), (3, 1), "3px", "black", "squared")
+            instance.styles[0],
+            ("LINEABOVE", (0, 1), (3, 1), "3px", "black", "squared", None),
         )
 
     def test_add_cell_styles_will_not_add_lineabove_style_if_bordertop_style_not_set_on_context_frag(
@@ -196,7 +197,7 @@ class TableDataTestCase(TestCase):
         instance.add_cell_styles(context, (0, 1), (3, 5), mode="tr")
         self.assertEqual(
             instance.styles[0],
-            ("LINEBEFORE", (0, 1), (0, 5), "3px", "black", "squared"),
+            ("LINEBEFORE", (0, 1), (0, 5), "3px", "black", "squared", None),
         )
 
     def test_add_cell_styles_will_not_add_linebefore_style_if_borderleft_style_not_set_on_context_frag(
@@ -240,7 +241,8 @@ class TableDataTestCase(TestCase):
         instance = self.sut()
         instance.add_cell_styles(context, (0, 1), (3, 5), mode="tr")
         self.assertEqual(
-            instance.styles[0], ("LINEAFTER", (3, 1), (3, 5), "3px", "black", "squared")
+            instance.styles[0],
+            ("LINEAFTER", (3, 1), (3, 5), "3px", "black", "squared", None),
         )
 
     def test_add_cell_styles_will_not_add_lineafter_style_if_borderright_style_not_set_on_context_frag(
@@ -284,7 +286,8 @@ class TableDataTestCase(TestCase):
         instance = self.sut()
         instance.add_cell_styles(context, (0, 1), (3, 5), mode="tr")
         self.assertEqual(
-            instance.styles[0], ("LINEBELOW", (0, 5), (3, 5), "3px", "black", "squared")
+            instance.styles[0],
+            ("LINEBELOW", (0, 5), (3, 5), "3px", "black", "squared", None),
         )
 
     def test_add_cell_styles_will_not_add_linebelow_style_if_borderbottom_style_not_set_on_context_frag(
@@ -337,17 +340,20 @@ class TableDataTestCase(TestCase):
         instance = self.sut()
         instance.add_cell_styles(context, (0, 1), (3, 5), mode="tr")
         self.assertEqual(
-            instance.styles[0], ("LINEABOVE", (0, 1), (3, 1), "3px", "black", "squared")
+            instance.styles[0],
+            ("LINEABOVE", (0, 1), (3, 1), "3px", "black", "squared", None),
         )
         self.assertEqual(
             instance.styles[1],
-            ("LINEBEFORE", (0, 1), (0, 5), "3px", "black", "squared"),
+            ("LINEBEFORE", (0, 1), (0, 5), "3px", "black", "squared", None),
         )
         self.assertEqual(
-            instance.styles[2], ("LINEAFTER", (3, 1), (3, 5), "3px", "black", "squared")
+            instance.styles[2],
+            ("LINEAFTER", (3, 1), (3, 5), "3px", "black", "squared", None),
         )
         self.assertEqual(
-            instance.styles[3], ("LINEBELOW", (0, 5), (3, 5), "3px", "black", "squared")
+            instance.styles[3],
+            ("LINEBELOW", (0, 5), (3, 5), "3px", "black", "squared", None),
         )
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,6 +10,7 @@ from xhtml2pdf.util import (
     getBox,
     getColor,
     getCoords,
+    getDashPattern,
     getFrameDimensions,
     getSize,
     set_value,
@@ -273,6 +274,33 @@ class GetBorderStyleTestCase(TestCase):
     def test_will_return_default_if_passed_value_is_non_case_sensitive_hidden(self):
         style = getBorderStyle("hidDen", default="defaultPassedArg")
         self.assertEqual(style, "defaultPassedArg")
+
+
+class GetDashPatternTestCase(TestCase):
+    def test_solid_returns_empty_dash(self):
+        dash, cap = getDashPattern("solid", 2)
+        self.assertEqual(dash, [])
+        self.assertEqual(cap, 0)
+
+    def test_dashed_returns_dash_pattern(self):
+        dash, cap = getDashPattern("dashed", 2)
+        self.assertEqual(dash, [6, 4])
+        self.assertEqual(cap, 0)
+
+    def test_dotted_returns_dot_pattern_with_round_cap(self):
+        dash, cap = getDashPattern("dotted", 3)
+        self.assertEqual(dash, [3, 6])
+        self.assertEqual(cap, 1)
+
+    def test_none_returns_empty_dash(self):
+        dash, cap = getDashPattern(None, 2)
+        self.assertEqual(dash, [])
+        self.assertEqual(cap, 0)
+
+    def test_unknown_style_returns_empty_dash(self):
+        dash, cap = getDashPattern("groove", 2)
+        self.assertEqual(dash, [])
+        self.assertEqual(cap, 0)
 
 
 class CopyUtils(TestCase):

--- a/xhtml2pdf/paragraph.py
+++ b/xhtml2pdf/paragraph.py
@@ -41,6 +41,8 @@ from reportlab.lib.enums import TA_CENTER, TA_JUSTIFY, TA_LEFT, TA_RIGHT
 from reportlab.pdfbase.pdfmetrics import stringWidth
 from reportlab.platypus.flowables import Flowable
 
+from xhtml2pdf.util import getDashPattern
+
 if TYPE_CHECKING:
     from reportlab.pdfgen.canvas import Canvas
 
@@ -121,6 +123,9 @@ class Box(dict):
                 if color is not None:
                     canvas.setStrokeColor(color)
                     canvas.setLineWidth(width)
+                    dash, cap = getDashPattern(bstyle, width)
+                    canvas.setDash(dash)
+                    canvas.setLineCap(cap)
                     canvas.line(x1, y1, x2, y2)
 
         _drawBorderLine(

--- a/xhtml2pdf/tables.py
+++ b/xhtml2pdf/tables.py
@@ -19,7 +19,7 @@ import logging
 from reportlab.platypus.tables import TableStyle
 
 from xhtml2pdf.tags import pisaTag
-from xhtml2pdf.util import getAlign, getBorderStyle, getSize, set_value
+from xhtml2pdf.util import getAlign, getBorderStyle, getDashPattern, getSize, set_value
 from xhtml2pdf.xhtml2pdf_reportlab import PmlKeepInFrame, PmlTable
 
 log = logging.getLogger(__name__)
@@ -107,6 +107,7 @@ class TableData:
             and c.frag.borderTopWidth
             and c.frag.borderTopColor is not None
         ):
+            dash, cap = getDashPattern(c.frag.borderTopStyle, c.frag.borderTopWidth)
             self.add_style(
                 (
                     "LINEABOVE",
@@ -114,7 +115,8 @@ class TableData:
                     (end[0], begin[1]),
                     c.frag.borderTopWidth,
                     c.frag.borderTopColor,
-                    "squared",
+                    cap or "squared",
+                    dash or None,
                 )
             )
         if (
@@ -122,6 +124,7 @@ class TableData:
             and c.frag.borderLeftWidth
             and c.frag.borderLeftColor is not None
         ):
+            dash, cap = getDashPattern(c.frag.borderLeftStyle, c.frag.borderLeftWidth)
             self.add_style(
                 (
                     "LINEBEFORE",
@@ -129,7 +132,8 @@ class TableData:
                     (begin[0], end[1]),
                     c.frag.borderLeftWidth,
                     c.frag.borderLeftColor,
-                    "squared",
+                    cap or "squared",
+                    dash or None,
                 )
             )
         if (
@@ -137,6 +141,7 @@ class TableData:
             and c.frag.borderRightWidth
             and c.frag.borderRightColor is not None
         ):
+            dash, cap = getDashPattern(c.frag.borderRightStyle, c.frag.borderRightWidth)
             self.add_style(
                 (
                     "LINEAFTER",
@@ -144,7 +149,8 @@ class TableData:
                     end,
                     c.frag.borderRightWidth,
                     c.frag.borderRightColor,
-                    "squared",
+                    cap or "squared",
+                    dash or None,
                 )
             )
         if (
@@ -152,6 +158,7 @@ class TableData:
             and c.frag.borderBottomWidth
             and c.frag.borderBottomColor is not None
         ):
+            dash, cap = getDashPattern(c.frag.borderBottomStyle, c.frag.borderBottomWidth)
             self.add_style(
                 (
                     "LINEBELOW",
@@ -159,7 +166,8 @@ class TableData:
                     end,
                     c.frag.borderBottomWidth,
                     c.frag.borderBottomColor,
-                    "squared",
+                    cap or "squared",
+                    dash or None,
                 )
             )
         self.add_style(("LEFTPADDING", begin, end, c.frag.paddingLeft or self.padding))

--- a/xhtml2pdf/util.py
+++ b/xhtml2pdf/util.py
@@ -168,6 +168,24 @@ def getBorderStyle(value, default=None):
     return default
 
 
+def getDashPattern(style, width):
+    """Return a (dash_array, line_cap) tuple for the given CSS border style.
+
+    ``width`` is the border width in points.  The returned ``dash_array``
+    can be passed directly to ``canvas.setDash()``.  ``line_cap`` should be
+    applied via ``canvas.setLineCap()`` — 1 (round) for dotted borders, 0
+    (butt) otherwise.
+    """
+    if not style:
+        return [], 0
+    name = str(style).lower()
+    if name == "dotted":
+        return [width, width * 2], 1
+    if name == "dashed":
+        return [width * 3, width * 2], 0
+    return [], 0
+
+
 MM: float = cm / 10.0
 DPI96: float = 1.0 / 96.0 * inch
 

--- a/xhtml2pdf/xhtml2pdf_reportlab.py
+++ b/xhtml2pdf/xhtml2pdf_reportlab.py
@@ -49,7 +49,7 @@ from reportlab.rl_config import register_reset
 
 from xhtml2pdf.files import pisaFileObject, pisaTempFile
 from xhtml2pdf.reportlab_paragraph import Paragraph
-from xhtml2pdf.util import ImageWarning, getBorderStyle
+from xhtml2pdf.util import ImageWarning, getBorderStyle, getDashPattern
 
 if TYPE_CHECKING:
     from reportlab.graphics.shapes import Drawing
@@ -732,10 +732,12 @@ class PmlParagraph(Paragraph, PmlMaxHeightMixIn):
                 # If no color for border is given, the text color is used (like defined by W3C)
                 if color is None:
                     color = style.textColor
-                    # print "Border", bstyle, width, color
                 if color is not None:
                     canvas.setStrokeColor(color)
                     canvas.setLineWidth(width)
+                    dash, cap = getDashPattern(bstyle, width)
+                    canvas.setDash(dash)
+                    canvas.setLineCap(cap)
                     canvas.line(x1, y1, x2, y2)
 
         _drawBorderLine(


### PR DESCRIPTION
### Short description

Dashed and dotted `border-style` values are now rendered correctly instead of falling back to solid lines.

### Proposed changes

- Added `getDashPattern()` in `util.py` that maps CSS border style names to ReportLab dash arrays and line cap values
- Updated `_drawBorderLine()` in both `xhtml2pdf_reportlab.py` (block-level elements) and `paragraph.py` (inline boxes) to call `canvas.setDash()` and `canvas.setLineCap()` before drawing each border segment
- Updated `tables.py` to pass the dash array into ReportLab's table line commands so table cell borders also render correctly
- Styles that don't have a meaningful dash mapping (`double`, `groove`, `ridge`, `inset`, `outset`) still render as solid — this matches previous behavior and can be extended later

### Resolved issues

Fixes: #432