### PR TITLE
fix(security): replace os.system in startViewer with safe subprocess.run argv list

### DIFF
--- a/xhtml2pdf/pisa.py
+++ b/xhtml2pdf/pisa.py
@@ -17,6 +17,7 @@ import getopt
 import glob
 import logging
 import os
+import subprocess
 import sys
 import urllib.parse as urlparse
 
@@ -403,8 +404,10 @@ def startViewer(filename):
         try:
             os.startfile(filename)
         except Exception:
-            # try to opan a la apple
-            os.system('open "%s"' % filename)
+            if sys.platform == "darwin":
+                subprocess.run(["open", filename], check=False)
+            elif sys.platform.startswith("linux"):
+                subprocess.run(["xdg-open", filename], check=False)
 
 
 def showLogging(*, debug=False):


### PR DESCRIPTION
## Summary

`startViewer(filename)` in `xhtml2pdf/pisa.py` formats user/caller-provided filenames directly into a shell string:
```python
os.system('open "%s"' % filename)
```
On Unix/macOS, passing a filename containing shell metacharacters (e.g. `"; touch /tmp/pwn; #`) or quotes executes arbitrary shell commands on the host (CWE-78: OS Command Injection).

## Fix

Replace `os.system('open "%s"' % filename)` with `subprocess.run(['open', filename], check=False)` on macOS and `subprocess.run(['xdg-open', filename], check=False)` on Linux, passing `filename` as a discrete argument vector.

- Preserves exact viewer functionality for legitimate filenames.
- Eliminates shell interpolation and command execution risks.
- Standard library only (`subprocess`).