### PR TITLE
Remove sys.exit() from handle_nextPageTemplate

### DIFF
--- a/tests/test_reportlab.py
+++ b/tests/test_reportlab.py
@@ -1,6 +1,10 @@
+from io import BytesIO
 from unittest import TestCase
 
-from xhtml2pdf import xhtml2pdf_reportlab
+from reportlab.lib.pagesizes import A4
+from reportlab.platypus.frames import Frame
+
+from xhtml2pdf import pisa, xhtml2pdf_reportlab
 
 
 class PTCycleTest(TestCase):
@@ -14,6 +18,53 @@ class PTCycleTest(TestCase):
         ptcycle.extend(range(10))
         for _ele in ptcycle:
             pass
+
+
+class PmlBaseDocTest(TestCase):
+    HTML = """
+        <html><head><style>
+        @page chapter_left  { size: a4 portrait; @frame { left: 2cm; top: 2cm;
+                              width: 16cm; height: 24cm; } }
+        @page chapter_right { size: a4 portrait; @frame { left: 3cm; top: 2cm;
+                              width: 16cm; height: 24cm; } }
+        </style></head>
+        <body>
+        <pdf:nexttemplate name="chapter" />
+        <p>one</p>
+        <pdf:nextpage />
+        <p>two</p>
+        </body></html>
+    """
+
+    @staticmethod
+    def _doc() -> xhtml2pdf_reportlab.PmlBaseDoc:
+        doc = xhtml2pdf_reportlab.PmlBaseDoc(BytesIO(), pagesize=A4)
+        doc.addPageTemplates(
+            [
+                xhtml2pdf_reportlab.PmlPageTemplate(
+                    id=f"chapter_{side}",
+                    frames=[Frame(0, 0, A4[0], A4[1], id=side)],
+                    pagesize=A4,
+                )
+                for side in ("left", "right")
+            ]
+        )
+        return doc
+
+    def test_next_page_template_cycles_left_and_right(self) -> None:
+        doc = self._doc()
+        doc.handle_nextPageTemplate("chapter")
+        cycle = doc._nextPageTemplateCycle
+        self.assertEqual(
+            [cycle.next_value.id for _ in range(4)],
+            ["chapter_left", "chapter_right", "chapter_left", "chapter_right"],
+        )
+
+    def test_alternating_templates_render(self) -> None:
+        output = BytesIO()
+        result = pisa.CreatePDF(self.HTML, dest=output)
+        self.assertFalse(result.err)
+        self.assertTrue(output.getvalue().startswith(b"%PDF"))
 
 
 class PmlMaxHeightMixInTest(TestCase):

--- a/xhtml2pdf/xhtml2pdf_reportlab.py
+++ b/xhtml2pdf/xhtml2pdf_reportlab.py
@@ -22,7 +22,7 @@ import sys
 from hashlib import md5
 from html import escape as html_escape
 from io import BytesIO, StringIO
-from typing import TYPE_CHECKING, ClassVar, Iterator
+from typing import TYPE_CHECKING, ClassVar
 from uuid import uuid4
 
 from PIL import Image as PILImage
@@ -36,6 +36,7 @@ from reportlab.platypus.doctemplate import (
     BaseDocTemplate,
     IndexingFlowable,
     PageTemplate,
+    PTCycle,
 )
 from reportlab.platypus.flowables import (
     CondPageBreak,
@@ -67,20 +68,6 @@ log = logging.getLogger(__name__)
 
 MAX_IMAGE_RATIO: float = 0.95
 PRODUCER: str = "xhtml2pdf <https://github.com/xhtml2pdf/xhtml2pdf/>"
-
-
-class PTCycle(list):
-    def __init__(self) -> None:
-        self._restart: int = 0
-        self._idx: int = 0
-        super().__init__()
-
-    def cyclicIterator(self) -> Iterator:
-        while 1:
-            yield self[self._idx]
-            self._idx += 1
-            if self._idx >= len(self):
-                self._idx = self._restart
 
 
 class PmlMaxHeightMixIn:
@@ -179,7 +166,6 @@ class PmlBaseDoc(BaseDocTemplate):
                     c._restart = len(c)
                     continue
                 for t in self.pageTemplates:
-                    sys.exit()
                     if t.id == ptn.strip():
                         c.append(t)
                         break
@@ -190,8 +176,8 @@ class PmlBaseDoc(BaseDocTemplate):
                 msg = "Invalid cycle restart position"
                 raise ValueError(msg)
 
-            # ensure we start on the first one$
-            self._nextPageTemplateCycle: PageTemplate = c.cyclicIterator()
+            # ensure we start on the first one
+            self._nextPageTemplateCycle: PTCycle = c
         else:
             msg = "Argument pt should be string or integer or list"
             raise TypeError(msg)


### PR DESCRIPTION
### Short description

`xhtml2pdf_reportlab.py:182` calls `sys.exit()` inside the loop that resolves an alternating page-template cycle, so `<pdf:nexttemplate>` on a name that has both `_left` and `_right` templates terminates the interpreter.

### Proposed changes

- Remove the `sys.exit()`.
- Use reportlab's `PTCycle` instead of the local fork, and store the cycle itself in `_nextPageTemplateCycle`.
- Two tests in `tests/test_reportlab.py`.

Reproduced with a document declaring `@page chapter_left` and `@page chapter_right` plus `<pdf:nexttemplate name="chapter" />` — the branch is reached from ordinary HTML, via the `_left`/`_right` expansion at the top of `handle_nextPageTemplate`:

```
before  SystemExit escaped CreatePDF  (xhtml2pdf_reportlab.py:182)
after   CreatePDF returned, err = 0, 1932 bytes
```

`SystemExit` derives from `BaseException`, so a caller wrapping `pisa.CreatePDF` in `except Exception` does not catch it; a worker rendering user-supplied HTML exits.

Deleting only the `sys.exit()` is not sufficient. `BaseDocTemplate._setPageTemplate` reads `self._nextPageTemplateCycle.next_value`, but the local `PTCycle` predates that API and `handle_nextPageTemplate` assigned `c.cyclicIterator()`, a generator, so the next page raises `AttributeError: 'generator' object has no attribute 'next_value'`. reportlab's own `PTCycle` has the same `_restart`/`_idx` semantics plus `next_value`/`peek`, present in reportlab 4.0.4, the minimum this project supports. Nothing in the tree called `cyclicIterator()`, so the local class is dropped rather than kept as a shim. Happy to keep a thin subclass instead.

Found by reading the reportlab shim for library code that terminates the process, not from a document in hand. There was no test for `handle_nextPageTemplate`.

Measured: `pytest tests/` → 177 passed on this branch, 175 before. Reverting only `xhtml2pdf_reportlab.py` and keeping the tests → 2 failed / 175 passed, both `SystemExit` at line 182. The naive variant that deletes only the `sys.exit()` also fails both, on `AttributeError: 'generator' object has no attribute 'next_value'` — which is what convinced me the second half of the change is needed.

`black` 24.4.2 and `ruff` 0.0.292 (the CI-pinned versions) are clean. `mypy` reports 27 errors, identical before and after — all pre-existing, none in the changed lines.

Not addressed: this does not touch #764, which fails in the `isinstance(pt, str)` branch with `can't find template(...)` — adjacent, different cause.

### Resolved issues

Fixes: #

Disclosure: this patch was written with AI assistance (Claude).
